### PR TITLE
Tidy OME files sections

### DIFF
--- a/about/licensing/index.html
+++ b/about/licensing/index.html
@@ -36,7 +36,7 @@ title: Licensing
         <hr class="whitespace">      
         <div class="row small-up-3 large-up-3 text-center">
             <div class="column">
-                <h4>OME-Files</h4>
+                <h4>OME Files</h4>
                 <hr>
                 <p>OME Files is released under the terms of a permissive <a href="https://github.com/ome/ome-files-cpp/blob/develop/LICENSE.md" target="_blank">BSD-2 license</a> which enables it to be used in non-GPL third party software. This means it may be used and redistributed with or without modification as long as the copyright notice is retained.</p>
             </div>

--- a/index.html
+++ b/index.html
@@ -47,10 +47,10 @@ title: Home
         </div>
         <!-- end Bio-Formats highlight -->
         
-         <!-- begin OME-Files highlight -->
+         <!-- begin OME Files highlight -->
             <hr class="whitespace">        
             <div class="row column text-center">
-                <h2><img src="{{ site.baseurl }}/img/logos/ome-files.svg" alt="OME-Files logo" class="section-title-logo" /></h2>
+                <h2><img src="{{ site.baseurl }}/img/logos/ome-files.svg" alt="OME Files logo" class="section-title-logo" /></h2>
                 <h5 class="subheader">OME Files is a reference implementation of the OME data model and the OME-TIFF file format for developers to use in their own software.</h5>
             </div>
             <hr>

--- a/products/index.html
+++ b/products/index.html
@@ -26,7 +26,7 @@ title: Products
                 <a href="{{ site.baseurl }}/products/bio-formats/" class="button expanded">Learn More</a>
             </div>
             <div class="medium-4 columns">
-                <h3><img src="{{ site.baseurl }}/img/logos/ome-files.svg" alt="OME-Files logo" class="section-title-img-logo" /></h3>                
+                <h3><img src="{{ site.baseurl }}/img/logos/ome-files.svg" alt="OME Files logo" class="section-title-img-logo" /></h3>                
                 <h6>The reference implementation of the OME data model and file formats</h6>
                 <hr>
                 <p>OME Files is a collection of tools and standards for developers wanting to integrate support for the OME data model and for reading and writing OME file formats into their software.</p>

--- a/products/ome-files/index.html
+++ b/products/ome-files/index.html
@@ -4,7 +4,7 @@ title: OME Files
 ---          
         <div class="callout large primary" id="bg-image-ome-files">
             <div class="row column text-center">
-                <h1 class="hero-main-header"><img src="{{ site.baseurl }}/img/logos/ome-files-white.svg" alt="OME-Files logo" class="logo-hero" /></h1>
+                <h1 class="hero-main-header"><img src="{{ site.baseurl }}/img/logos/ome-files-white.svg" alt="OME Files logo" class="logo-hero" /></h1>
                 <p>OME Files, the solution for developers to support the OME data model and OME-TIFF in their software</p>
             </div>
         </div>
@@ -12,7 +12,7 @@ title: OME Files
         <!-- begin -->
         <hr class="whitespace">        
         <div class="row column text-center">
-            <h2>What is OME-Files?</h2>
+            <h2>What is OME Files?</h2>
         </div>
         <hr>
         <div class="row">
@@ -58,7 +58,7 @@ title: OME Files
                 </div>
                 <hr>
                 <div class="text-center">
-                    <h4 class="hero-subheader">OME Files was developed by the Open Microscopy Environment consortium. Licensing information is on the main <a href="#">OME licensing page</a>.</h2>
+                    <h4 class="hero-subheader">OME Files was developed by the Open Microscopy Environment consortium. Licensing information is on the main <a href="{{ site.baseurl }}/about/licensing/">OME licensing page</a>.</h2>
                 </div>
             </div>
         </header>


### PR DESCRIPTION
Removing the rest of the stray 'OME-Files' references and fixing a link that hadn't been properly put in place.

Staged at https://snoopycrimecop.github.io/www.openmicroscopy.org/products/ome-files/ etc