### PR TITLE
Enable Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site
 .DS_Store
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ env:
 install: bundle install
 script:
     - bundle exec jekyll build
-    - bundle exec htmlproofer ./_site
+    # - bundle exec htmlproofer ./_site

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+sudo: false
+cache: bundler
+rvm: 2.3.3
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+install: bundle install
+script:
+    - bundle exec jekyll build
+    - bundle exec htmlproofer ./_site

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,26 @@
+source "https://rubygems.org"
+ruby RUBY_VERSION
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll", "3.4.3"
+
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+   gem "jekyll-feed", "~> 0.6"
+end
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "html-proofer"


### PR DESCRIPTION
This PR enables the Travis build of this repository, including a top-level `Gemfile` with the dependencies and the execution of `jekyll build`.

Note the `htmlproofer` step is currently excluded as the current branch reports 1200 broken links. 