### PR TITLE
Add internal htmlproofer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ env:
 install: bundle install
 script:
     - bundle exec jekyll build  -d _site/www.openmicroscopy.org
-    - bundle exec htmlproofer ./_site
+    - bundle exec htmlproofer ./_site --disable-external

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ env:
 install: bundle install
 script:
     - bundle exec jekyll build  -d _site/www.openmicroscopy.org
-    - bundle exec htmlproofer ./_site --disable-external
+    - bundle exec htmlproofer ./_site --disable-external || echo "Failed"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 install: bundle install
 script:
-    - bundle exec jekyll build
-    # - bundle exec htmlproofer ./_site
+    - bundle exec jekyll build  -d _site/www.openmicroscopy.org
+    - bundle exec htmlproofer ./_site


### PR DESCRIPTION
See https://trello.com/c/HkZodeZY/46-add-internal-linkchecker-to-travis

This PR adds the `htmlproofer` step to the Travis build for checking internal links. The `jekyll build` step uses `_site/{{ baseurl }}` in order to allow `htmlproofer` to validate internal links.

At the moment, the `htmlproofer` is set up to be non failing but the logs give information about all internal failing URLs (137 as of this PR) so that we can start fixing them. Once everything is corrected, f8c518e should be reverted so that the failed linkchecks fail Travis.