### PR TITLE
OMERO downloads 5.3.2

### DIFF
--- a/products/omero/downloads/index.html
+++ b/products/omero/downloads/index.html
@@ -154,7 +154,7 @@ title: OMERO Downloads
                                             <img class="thumbnail" src="http://placehold.it/480x280">
                                             <h5>Source Code</h5>
                                             <h6>openmicroscopy-5.3.2.zip</h6>
-                                            <h6>Checksum: bf68510e (<a href="#">SHA1</a>)</h6>
+                                            <h6>Checksum: bf68510e (<a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/openmicroscopy-5.3.2.zip.sha1">SHA1</a>)</h6>
                                             <p>Instructions for installing the source code can be found at: <a href="http://www.openmicroscopy.org/site/support/omero/developers/installation.html" target="_blank">Installing OMERO from source</a>.</p>
                                             <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/openmicroscopy-5.3.2.zip" class="button hollow large expanded"><i class="fa fa-download"></i> Download (43.03 MB)</a>                                                            
                                         </div>

--- a/products/omero/downloads/index.html
+++ b/products/omero/downloads/index.html
@@ -4,8 +4,7 @@ title: OMERO Downloads
 ---     
         <div class="callout large primary">
             <div class="row column text-center">
-                <h1>OMERO [Version x.x] Downloads</h1>
-                <p>[ a blurb about the Downloads ]</p>
+                <h1>OMERO 5.3.2 Downloads</h1>
             </div>
         </div>
         
@@ -17,10 +16,10 @@ title: OMERO Downloads
                     <div class="small-12 columns">                                   
                         <div class="column row">
                             <ul class="tabs" data-tabs id="example-tabs">
-                                <li class="tabs-title is-active"><a href="#panel1" aria-selected="true">OMERO client</a></li>
-                                <li class="tabs-title"><a href="#panel2">OMERO plugin</a></li>
+                                <li class="tabs-title is-active"><a href="#panel1" aria-selected="true">OMERO clients</a></li>
+                                <li class="tabs-title"><a href="#panel2">OMERO plugins</a></li>
                                 <li class="tabs-title"><a href="#panel3">OMERO server</a></li>
-                                <li class="tabs-title"><a href="#panel4">OMERO API</a></li>
+                                <li class="tabs-title"><a href="#panel4">OMERO API Docs</a></li>
                                 <li class="tabs-title"><a href="#panel5">OMERO Python</a></li>
                                 <li class="tabs-title"><a href="#panel6">OMERO Java</a></li>
                                 <li class="tabs-title"><a href="#panel7">Code</a></li>
@@ -28,58 +27,58 @@ title: OMERO Downloads
                             <div class="tabs-content text-center" data-tabs-content="example-tabs">
                                 <!-- begin Panel 1 options -->
                                 <div class="tabs-panel is-active" id="panel1">
-                                    <h3>OMERO client</h3>
+                                    <h3>OMERO clients</h3>
                                     <hr class="whitespace hide-for-small-only">
                                     <div class="row medium-up-2 large-up-2">
                                         <div class="column">
                                             <img class="thumbnail" src="http://placehold.it/280x180">
                                             <h5>Windows</h5>
-                                            <h6>OMERO.insight-5.2.6-ice35-b35-win.zip</h6>
-                                            <h6>Checksum: 48a1cdce (<a href="#">SHA1</a>)</h6>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (84.47 MB)</a>                                                            
+                                            <h6>OMERO.insight-5.3.2-ice36-b62-win.zip</h6>
+                                            <h6>Checksum: 5441c1f5 (<a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.insight-5.3.2-ice36-b62-win.zip.sha1">SHA1</a>)</h6>
+                                            <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.insight-5.3.2-ice36-b62-win.zip" class="button hollow large expanded"><i class="fa fa-download"></i> Download (78.39 MB)</a>                                                            
                                         </div>
                                         <div class="column">
                                             <img class="thumbnail" src="http://placehold.it/280x180">
                                             <h5>Mac OS X</h5>
-                                            <h6>OMERO.insight-5.2.6-ice35-b35-mac.zip</h6>
-                                            <h6>Checksum: 36c96035 (<a href="#">SHA1</a>)</h6>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (83.25 MB)</a>                                                            
+                                            <h6>OMERO.insight-5.3.2-ice36-b62-mac.zip</h6>
+                                            <h6>Checksum: 267ac3ae (<a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.insight-5.3.2-ice36-b62-mac.zip.sha1">SHA1</a>)</h6>
+                                            <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.insight-5.3.2-ice36-b62-mac.zip" class="button hollow large expanded"><i class="fa fa-download"></i> Download (78.17 MB)</a>                                                            
                                         </div>
                                         <hr class="whitespace hide-for-small-only">
                                         <div class="column">
                                             <img class="thumbnail" src="http://placehold.it/280x180">
                                             <h5>Linux</h5>
-                                            <h6>OMERO.insight-5.2.6-ice35-b35-linux.zip</h6>
-                                            <h6>Checksum: 4c748769 (<a href="#">SHA1</a>)</h6>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (83.12 MB)</a>                                                            
+                                            <h6>OMERO.insight-5.3.2-ice36-b62-linux.zip</h6>
+                                            <h6>Checksum: e05fdc7b (<a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.insight-5.3.2-ice36-b62-linux.zip.sha1">SHA1</a>)</h6>
+                                            <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.insight-5.3.2-ice36-b62-linux.zip" class="button hollow large expanded"><i class="fa fa-download"></i> Download (78.04 MB)</a>                                                            
                                         </div>
                                         <hr class="whitespace">
                                         <div class="row">
                                             <p>OMERO.web is part of the server package, so individual users do not need to install it locally.</p>
-                                            <p>Full instructions for installing the client are on the Help website: Getting Started with OMERO.insight Version 5.2.6.</p>                                            
+                                            <p>Full instructions for installing the client are on the Help website: <a href="http://help.openmicroscopy.org/getting-started-5.html" target="_blank">Getting Started with OMERO.insight</a>.</p>                                            
                                         </div>                                        
                                     </div>
                                 </div>
                                 <!-- begin Panel 2 options -->
                                 <div class="tabs-panel" id="panel2">
-                                    <h3>OMERO plugin</h3>
+                                    <h3>OMERO plugins</h3>
                                     <hr class="whitespace hide-for-small-only">
                                     <div class="row medium-up-2 large-up-2">
                                         <div class="column">
                                             <img class="thumbnail" src="http://placehold.it/280x180">
                                             <h5>Image J / Fiji</h5>
-                                            <h6>OMERO.insight-ij-5.2.6-ice35-b35.zip</h6>
-                                            <h6>Checksum: eb5e6dc9 (<a href="#">SHA1</a>)</h6>
+                                            <h6>OMERO.insight-ij-5.3.2-ice36-b62.zip</h6>
+                                            <h6>Checksum: 966e2d79 (<a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.insight-ij-5.3.2-ice36-b62.zip.sha1">SHA1</a>)</h6>
                                             <p>Instructions for downloading and installing the ImageJ plugin: <a href="http://help.openmicroscopy.org/imagej.html" target="_blank">Using ImageJ with OMERO</a>.</p>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (76.56 MB)</a>                                                            
+                                            <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.insight-ij-5.3.2-ice36-b62.zip" class="button hollow large expanded"><i class="fa fa-download"></i> Download (70.23 MB)</a>                                                            
                                         </div>
                                         <div class="column">
                                             <img class="thumbnail" src="http://placehold.it/280x180">
                                             <h5>Matlab</h5>
-                                            <h6>OMERO.matlab-5.2.6-ice35-b35.zip</h6>
-                                            <h6>Checksum: 21a8d91a (<a href="#">SHA1</a>)</h6>
-                                            <p>Instructions for using the Matlab plugin are at: <a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/Matlab.html" target="_blank">OMERO Matlab language bindings</a>.</p>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (21.21 MB)</a>                                                            
+                                            <h6>OMERO.matlab-5.3.2-ice36-b62.zip</h6>
+                                            <h6>Checksum: c815c35f (<a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.matlab-5.3.2-ice36-b62.zip.sha1">SHA1</a>)</h6>
+                                            <p>Instructions for using the Matlab plugin are at: <a href="http://www.openmicroscopy.org/site/support/omero/developers/Matlab.html" target="_blank">OMERO Matlab language bindings</a>.</p>
+                                            <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.matlab-5.3.2-ice36-b62.zip" class="button hollow large expanded"><i class="fa fa-download"></i> Download (22.49 MB)</a>                                                            
                                         </div>
                                         <hr class="whitespace">
                                     </div>
@@ -91,33 +90,26 @@ title: OMERO Downloads
                                     <div class="row medium-up-2 large-up-2">
                                         <div class="column">
                                             <img class="thumbnail" src="http://placehold.it/280x180">
-                                            <h5>Server (Ice 3.5)</h5>
-                                            <h6>OMERO.server-5.2.6-ice35-b35.zip</h6>
-                                            <h6>Checksum: 60ed265f (<a href="#">SHA1</a>)</h6>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (165.02 MB)</a>                                                            
-                                        </div>
-                                        <div class="column">
-                                            <img class="thumbnail" src="http://placehold.it/280x180">
                                             <h5>Server (Ice 3.6)</h5>
-                                            <h6>OMERO.server-5.2.6-ice36-b35.zip</h6>
-                                            <h6>Checksum: 2675d9b7 (<a href="#">SHA1</a>)</h6>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (152.39 MB)</a>                                                            
+                                            <h6>OMERO.server-5.3.2-ice36-b62.zip</h6>
+                                            <h6>Checksum: 0f910f94 (<a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.server-5.3.2-ice36-b62.zip.sha1">SHA1</a>)</h6>
+                                            <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.server-5.3.2-ice36-b62.zip" class="button hollow large expanded"><i class="fa fa-download"></i> Download (155.8 MB)</a>                                                            
                                         </div>
                                         <hr class="whitespace">
                                     </div>
                                 </div>
                                 <!-- begin Panel 4 options -->
                                 <div class="tabs-panel" id="panel4">
-                                    <h3>OMERO API</h3>
+                                    <h3>OMERO API Docs</h3>
                                     <hr class="whitespace hide-for-small-only">
                                     <div class="row medium-up-1 large-up-1">
                                         <div class="column">
                                             <img class="thumbnail" src="http://placehold.it/480x280">
                                             <h5>API Documentation</h5>
-                                            <h6>OMERO.docs-5.2.6-ice35-b35.zip</h6>
-                                            <h6>Checksum: 76b982c6 (<a href="#">SHA1</a>)</h6>
-                                            <p>[ Helen: Can we add a blurb here about what this is? ] The OMERO API documentation is also available to read on the web <a href="#">here</a>.</p>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (33.8 MB)</a>                                                            
+                                            <h6>OMERO.apidoc-5.3.2-ice36-b62.zip</h6>
+                                            <h6>Checksum: eae4c0ac (<a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.apidoc-5.3.2-ice36-b62.zip.sha1">SHA1</a>)</h6>
+                                            <p>The OMERO API documentation is also available to read on the web <a href="http://downloads.openmicroscopy.org/omero/5.3.2/api/">here</a>.</p>
+                                            <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.apidoc-5.3.2-ice36-b62.zip" class="button hollow large expanded"><i class="fa fa-download"></i> Download (34.48 MB)</a>                                                            
                                         </div>
                                     </div>
                                 </div>
@@ -128,17 +120,11 @@ title: OMERO Downloads
                                     <div class="row medium-up-2 large-up-2">
                                         <div class="column">
                                             <img class="thumbnail" src="http://placehold.it/280x180">
-                                            <h5>Python (Ice 3.5)</h5>
-                                            <h6>OMERO.py-5.2.6-ice35-b35.zip</h6>
-                                            <h6>Checksum: 0aa2f369 (<a href="#">SHA1</a>)</h6>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (8.28 MB)</a>                                                            
-                                        </div>
-                                        <div class="column">
-                                            <img class="thumbnail" src="http://placehold.it/280x180">
                                             <h5>Python (Ice 3.6)</h5>
-                                            <h6>OMERO.py-5.2.6-ice36-b35.zip</h6>
-                                            <h6>Checksum: 004dd365 (<a href="#">SHA1</a>)</h6>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (8.3 MB)</a>                                                            
+                                            <h6>OMERO.py-5.3.2-ice36-b62.zip</h6>
+                                            <h6>Checksum: adb65d15 (<a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.py-5.3.2-ice36-b62.zip.sha1">SHA1</a>)</h6>
+                                            <p>The OMERO Python API documentation is available to read on the web <a href="http://downloads.openmicroscopy.org/omero/5.3.2/api/python/">here</a>.</p>
+                                            <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.py-5.3.2-ice36-b62.zip" class="button hollow large expanded"><i class="fa fa-download"></i> Download (9.09 MB)</a>                                                            
                                         </div>
                                         <hr class="whitespace">
                                     </div>
@@ -150,17 +136,11 @@ title: OMERO Downloads
                                     <div class="row medium-up-2 large-up-2">
                                         <div class="column">
                                             <img class="thumbnail" src="http://placehold.it/280x180">
-                                            <h5>Java (Ice 3.5)</h5>
-                                            <h6>OMERO.java-5.2.6-ice35-b35.zip</h6>
-                                            <h6>Checksum: 4365b0c2 (<a href="#">SHA1</a>)</h6>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (87.33 MB)</a>                                                            
-                                        </div>
-                                        <div class="column">
-                                            <img class="thumbnail" src="http://placehold.it/280x180">
                                             <h5>Java (Ice 3.6)</h5>
-                                            <h6>OMERO.java-5.2.6-ice36-b35.zip</h6>
-                                            <h6>Checksum: 160995e7 (<a href="#">SHA1</a>)</h6>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (79.62 MB)</a>                                                            
+                                            <h6>OMERO.java-5.3.2-ice36-b62.zip</h6>
+                                            <h6>Checksum: 0dd14111 (<a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.java-5.3.2-ice36-b62.zip.sha1">SHA1</a>)</h6>
+                                            <p>The OMERO Java API documentation is available to read on the web <a href="http://downloads.openmicroscopy.org/omero/5.3.2/api/">here</a>.</p>
+                                            <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.java-5.3.2-ice36-b62.zip" class="button hollow large expanded"><i class="fa fa-download"></i> Download (80.81 MB)</a>                                                            
                                         </div>
                                         <hr class="whitespace">
                                     </div>
@@ -173,10 +153,10 @@ title: OMERO Downloads
                                         <div class="column">
                                             <img class="thumbnail" src="http://placehold.it/480x280">
                                             <h5>Source Code</h5>
-                                            <h6>openmicroscopy-5.2.6.zip</h6>
-                                            <h6>Checksum: ea8ce0ea (<a href="#">SHA1</a>)</h6>
-                                            <p>Instructions for installing the source code can be found at: <a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/installation.html" target="_blank">Installing OMERO from source</a>.</p>
-                                            <a href="#" class="button hollow large expanded"><i class="fa fa-download"></i> Download (42.2 MB)</a>                                                            
+                                            <h6>openmicroscopy-5.3.2.zip</h6>
+                                            <h6>Checksum: bf68510e (<a href="#">SHA1</a>)</h6>
+                                            <p>Instructions for installing the source code can be found at: <a href="http://www.openmicroscopy.org/site/support/omero/developers/installation.html" target="_blank">Installing OMERO from source</a>.</p>
+                                            <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/openmicroscopy-5.3.2.zip" class="button hollow large expanded"><i class="fa fa-download"></i> Download (43.03 MB)</a>                                                            
                                         </div>
                                     </div>
                                     <hr class="whitespace hide-for-small-only">
@@ -185,7 +165,7 @@ title: OMERO Downloads
                                             <a href="http://github.com/openmicroscopy/openmicroscopy" target="_blank" class="button hollow large expanded"><i class="fa fa-github"></i> View GitHub Repository</a>                                                            
                                         </div>
                                         <div class="column">
-                                            <a href="https://github.com/openmicroscopy/openmicroscopy/tree/v5.2.6" target="_blank" class="button hollow large expanded"><i class="fa fa-github"></i> View Git Tag</a>                                                            
+                                            <a href="https://github.com/openmicroscopy/openmicroscopy/tree/v5.3.2" target="_blank" class="button hollow large expanded"><i class="fa fa-github"></i> View Git Tag</a>                                                            
                                         </div>
                                     </div>
                                         <hr class="whitespace">
@@ -203,8 +183,8 @@ title: OMERO Downloads
             <div class="medium-12 large-12 columns">
                 <div class="warning callout">
                     <h3>Things to Note</h3>
-                    <p>Information on this release of OMERO is in the <a href="#" target="_blank">release announcement</a>.</p>
-                    <p>Full documentation is available as <a href="http://www.openmicroscopy.org/site/support/omero5.2" target="_blank">web documentation and there are user guides for the clients on our <a href="http://help.openmicroscopy.org/" target="_blank">Help website</a>.</p>
+                    <p>Information on this release of OMERO is in the <a href="https://www.openmicroscopy.org/community/viewtopic.php?f=11&t=8284" target="_blank">release announcement</a>.</p>
+                    <p>Full documentation is available as <a href="http://www.openmicroscopy.org/site/support/omero5.3" target="_blank">web documentation</a> and there are user guides for the clients on our <a href="http://help.openmicroscopy.org/" target="_blank">Help website</a>.</p>
                     <p>A standard OMERO user just needs to download the client package with the same major version as their institutional server e.g., 5.2.0 clients will connect to 5.2.5 servers but not to 5.3.0 servers.</p>
                     <p>If you do not have an institutional server, you can <a href="http://qa.openmicroscopy.org.uk/registry/demo_account/" target="_blank">apply for an account on our Demo server</a>.</p>                
                 </div>

--- a/products/omero/index.html
+++ b/products/omero/index.html
@@ -8,7 +8,7 @@ title: OMERO
                     <h1 class="hero-main-header"><img src="{{ site.baseurl }}/img/logos/omero-white.svg" alt="OMERO logo" class="logo-hero" /></h1>
                     <h5 class="hero-subheader small-12 medium-12 large-12">From the microscope to publication, OMERO handles all your images in a secure central repository. You can view, organize, analyze and share your data from anywhere you have internet access. Work with your images from a desktop app (Windows, Mac or Linux), from the web or from 3rd party software. Over 140 image file formats supported, including all major microscope formats.</h5>
                     <br>
-                    <a href="{{ site.baseurl }}/products/omero/downloads/" class="large button sites-button hide-for-small-only">Download [Version X.X.X]</a>
+                    <a href="{{ site.baseurl }}/products/omero/downloads/" class="large button sites-button hide-for-small-only">Download Version 5.3.2</a>
                 </div>
             </div>
             <hr class="whitespace">


### PR DESCRIPTION
As per https://trello.com/c/tRP9Tayo/44-omero-downloads-page-post-5-3-2 this PR updates https://snoopycrimecop.github.io/www.openmicroscopy.org/products/omero/downloads/ to match http://downloads.openmicroscopy.org/omero/5.3.2/ and serve the latest downloads.