### PR TITLE
Add icons to user group index pages

### DIFF
--- a/products/omero/developers/index.html
+++ b/products/omero/developers/index.html
@@ -49,19 +49,19 @@ usergroup: Developers
                 <a class="button hollow tiny expanded" href="http://www.openmicroscopy.org/site/support/omero/developers/GettingStarted/AdvancedClientDevelopment.html" target="_blank">View Developer Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_command-line.svg">
                 <h5>OMERO.cli</h5>
                 <p>Use the CLI to work with OMERO objects and write plugins.</p>
                 <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/cli/index.html" target="_blank">View Developer Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_scripts.svg">
                 <h5>Scripting Service</h5>
                 <p>Write Python scripts to add functionality to the OMERO.server. <a href="https://www.openmicroscopy.org/site/community/scripts" target="_blank">Share your scripts</a> with the community.</p>
                 <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/developers/index.html#omero-scripts-plugins-for-omero" target="_blank">View Developer Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_analytics.svg">
                 <h5>Analysis</h5>
                 <p>Save your analysis results to OMERO.server or use OMERO.tables to store columnar data.</p>
                 <a class="button hollow tiny expanded" href="http://www.openmicroscopy.org/site/support/omero/developers/index.html#analysis" target="_blank">View Developer Guide</a>

--- a/products/omero/institution/index.html
+++ b/products/omero/institution/index.html
@@ -25,21 +25,21 @@ usergroup: institutions
         <hr>        
         <div class="row small-up-2 large-up-4">
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_bio-formats.svg">
                 <h5>Supported File Formats</h5>
                 <p>OMERO imports all the formats read by Bio-Formats including microscopy, HCS, tissue scanner and graphics file formats. Over 140 in total.</p>
                 <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/bio-formats/supported-formats.html" target="_blank">View Supported Formats</a>
                 <a class="button hollow tiny expanded" href="{{ site.baseurl }}/products/omero/import/">Learn more about importing</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_manage.svg">
                 <h5>Permissions</h5>
                 <p>OMERO permissions functionality allows users to share data within groups of scientists and collaborate on their data.</p>
                 <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/sysadmins/server-permissions.html" target="_blank">View Sysadmin Guide</a>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/facility-manager.html" target="_blank">View Facility Manager Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_public-group.svg">
                 <h5>Publish Data</h5>
                 <p>OMERO can be customized to host public data, allowing publication of images directly from an existing server via shareable URLs or via an embedded OMERO.web viewer.</p>
                 <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/sysadmins/index.html#optimizing-omero-as-a-data-repository
@@ -47,39 +47,33 @@ usergroup: institutions
                 <a class="button hollow tiny expanded" href="{{ site.baseurl }}/products/omero/publish/">Learn more about publishing</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_manage.svg">
                 <h5>Manage Users &amp; Groups</h5>
                 <p>Server administrators can add and manage users and groups with the admin tools.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/facility-manager.html#manage" target="_blank">View Sysadmin Guide</a>
                 <a class="button hollow tiny expanded" href="{{ site.baseurl }}/products/omero/utility/">Learn more about administrating</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_ldap.png">
                 <h5>LDAP Support</h5>
                 <p>Lightweight Directory Access Protocol (LDAP) is supported to allow existing institutional authentication services to be used for OMERO.</p>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero5.2/sysadmins/server-ldap.html" target="_blank">View Sysadmin Guide</a>
+                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/sysadmins/server-ldap.html" target="_blank">View Sysadmin Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
-                <h5>OMERO.mail</h5>
-                <p>Sysadmins can use OMERO.mail GUI to email users from the server.</p>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero5.1/sysadmins/mail.html" target="_blank">View Configuration Guide</a>
-            </div>
-            <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_command-line.svg">
                 <h5>Command Line</h5>
                 <p>The Command Line Interface enables a range of OMERO functions to be performed efficiently on single or batches of images.</p>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero5/users/cli/index.html" target="_blank">View User Guide</a>
-                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero5/sysadmins/cli/index.html" target="_blank">View Sysadmin Guide</a>
+                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/users/cli/index.html" target="_blank">View User Guide</a>
+                <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/sysadmins/cli/index.html" target="_blank">View Sysadmin Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_integrity-reports.svg">
                 <h5>File Integrity Reports</h5>
                 <p>Import process checks uploaded files aren't corrupted giving extra confidence that they are safely stored.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/importing-data-5.html" target="_blank">View User Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_dropbox.svg">
                 <h5>DropBox</h5>
                 <p>Full-fledged “DropBox" allows automatic import from a defined directory of all supported file formats.</p>
                 <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero5/sysadmins/dropbox.html" target="_blank">View Sysadmin Guide</a>

--- a/products/omero/scientists/index.html
+++ b/products/omero/scientists/index.html
@@ -13,32 +13,32 @@ usergroup: scientists
             <h5 class="subheader">Using the power of Bio-Formats, OMERO supports over 140 image file formats, including all major microscope formats.</h5>
             <div class="row small-up-3 large-up-3">
                 <div class="column text-center">
-                    <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                    <i class="fa fa-arrow-up fa-4x"></i>
                     <p>Upload your data via the desktop app or command line, use our custom dropbox tool, or have your facility manager import it for you</p>
                     <a href="{{ site.baseurl }}/products/omero/import/" class="button expanded">Learn more about importing</a>
                 </div>
                 <div class="column text-center">
-                    <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                    <i class="fa fa-sitemap fa-4x"></i>
                     <p>View and organize your data from anywhere you have internet access</p>
                     <a href="{{ site.baseurl }}/products/omero/organize/" class="button expanded">Learn more about organizing</a>
                 </div>
                 <div class="column text-center">
-                    <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                    <i class="fa fa-eye fa-4x"></i>
                     <p>Work with your images using the OMERO.insight desktop app, with OMERO.web in your browser, or from 3rd party software</p>
                     <a href="{{ site.baseurl }}/products/omero/view/" class="button expanded">Learn more about viewing</a>
                 </div>
                 <div class="column text-center">
-                    <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                    <i class="fa fa-line-chart fa-4x"></i>
                     <p>Use ImageJ, MATLAB, R, scripts and other tools to run analysis on data in OMERO and save results on the server</p>
                     <a href="{{ site.baseurl }}/products/omero/analyze/" class="button expanded">Learn more about analyzing</a>
                 </div>
                 <div class="column text-center">
-                    <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                    <i class="fa fa-sitemap fa-4x"></i>
                     <p>Share data with collaborators or your PI via URLs</p>
                     <a href="{{ site.baseurl }}/products/omero/organize/" class="button expanded">Learn more about sharing</a>
                 </div>
                 <div class="column text-center">
-                    <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                    <i class="fa fa-rocket fa-4x"></i>
                     <p>Publish direct from the server via a customized website or embedded viewer</p>
                     <a href="{{ site.baseurl }}/products/omero/publish/" class="button expanded">Learn more about publishing</a>
                 </div>

--- a/products/omero/scientists/index.html
+++ b/products/omero/scientists/index.html
@@ -55,49 +55,49 @@ usergroup: scientists
         <hr>        
         <div class="row small-up-2 large-up-4">
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_import.svg">
                 <h5>Import Data</h5>
                 <p>Import over 140 image formats from microscope, graphics and other imaging formats, using the OMERO.insight app.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/importing-data-5.html" target="_blank">View User Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_view-images.svg">
                 <h5>View Data</h5>
                 <p>Use OMERO.insight and OMERO.web to work with image data over the internet from anywhere.  Browse thumbnails, image previews and view in full viewer including 'split-channel' view and Z-projection.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/viewing-data.html" target="_blank">View User Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_rendering-settings.svg">
                 <h5>Set and Adjust Rendering</h5>
                 <p>Rendering settings, including colours and intensity ranges can be adjusted and saved for any image. In appropriate groups, other group members can save their own settings for shared images.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/viewing-data.html#rendering" target="_blank">View User Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_rois.svg">
                 <h5>Create ROIs</h5>
                 <p>The Measurement Tool in OMERO.insight is used to draw Regions of Interest (ROIs) and enable some basic analysis to be performed.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/measurement-tool.html" target="_blank">View User Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_annotate.svg">
                 <h5>Add Metadata</h5>
                 <p>Add tags, key-value pairs, comments, ratings or file attachments to single or multiple images or containers. Search sort or interact with data based on these annotations.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/managing-data.html#annotating" target="_blank">View User Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_create-figures.svg">
                 <h5>Draw Figures</h5>
                 <p>Use <a href="http://figure.openmicroscopy.org" target="_blank">OMERO.figure</a> to draw figures quickly and easily for publications, presentations and meetings, save them on the OMERO server, and export as vector graphics.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/figure.html" target="_blank">View User Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_share.svg">
                 <h5>Collaborate</h5>
                 <p>OMERO Groups enable sharing of data, annotations and figures within groups of scientists. Browse multiple groups and move data between them. <a href="http://help.openmicroscopy.org/group-owner.html" target="_blank">Group owners</a> have extra capabilities</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/sharing-data.html" target="_blank">View User Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x300" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_fiji.png">
                 <h5>Use with ImageJ/Fiji</h5>
                 <p>The OMERO ImageJ plugin enables images on OMERO to be opened directly in ImageJ/Fiji. Save ROIs and overlays, results, new images or modified images from ImageJ into OMERO.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/imagej.html" target="_blank">View User Guide</a>


### PR DESCRIPTION
Re-uses the icons created so far to illustrate https://snoopycrimecop.github.io/www.openmicroscopy.org/products/omero/scientists/index.html
https://snoopycrimecop.github.io/www.openmicroscopy.org/products/omero/developers/index.html
https://snoopycrimecop.github.io/www.openmicroscopy.org/products/omero/institution/index.html

Also removed OMERO.mail from institutional key features as not a priority feature and gives us a round 8 features like the other pages.

Still icons to add to the dev index page