### PR TITLE
More image reuse

### DIFF
--- a/products/omero/developers/docs.html
+++ b/products/omero/developers/docs.html
@@ -13,17 +13,17 @@ usergroup: Developers
         <div class="row small-up-3 large-up-3 text-center">
             <div class="column">
                 <h4>OMERO developers documentation</h4>
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                <img class="thumbnail logomark" alt="OMERO logo" src="{{ site.baseurl }}/img/logos/omero-logomark.svg">
                 <a href="https://www.openmicroscopy.org/site/support/omero/developers/index.html" target="_blank" class="button">Read the Docs</a>
             </div>
             <div class="column">
                 <h4>OMERO API documentation</h4>
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO API icon" src="{{ site.baseurl }}/img/icons/omero-features-icons_public-api.svg">
                 <a href="http://downloads.openmicroscopy.org/latest/omero/api/" target="_blank" class="button">Read the Docs</a>
             </div>
             <div class="column">
                 <h4>OME Contributing Developers documentation</h4>
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                <img class="thumbnail logomark" alt="OME logo" src="{{ site.baseurl }}/img/logos/ome-logomark.svg">
                 <a href="https://www.openmicroscopy.org/site/support/contributing/" target="_blank" class="button">Read the Docs</a>
             </div>
         

--- a/products/omero/institution/docs.html
+++ b/products/omero/institution/docs.html
@@ -13,13 +13,13 @@ usergroup: institutions
         <div class="row small-up-2 large-up-2 text-center">
             <div class="column">
                 <h4>Introductory guide<br>for facility managers</h4>
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                <i class="fa fa-life-ring fa-4x"></i>
                 <p></p>
                 <a href="http://help.openmicroscopy.org/facility-manager.html" target="_blank" class="button">Read the Docs</a>
             </div>
             <div class="column">
                 <h4>OMERO system administrator documentation</h4>
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                <img class="thumbnail logomark" alt="OMERO logo" src="{{ site.baseurl }}/img/logos/omero-logomark.svg">
                 <p></p>
                 <a href="https://www.openmicroscopy.org/site/support/omero/sysadmins/index.html" target="_blank" class="button">Read the Docs</a>
             </div>

--- a/products/omero/institution/getting-started.html
+++ b/products/omero/institution/getting-started.html
@@ -25,19 +25,19 @@ usergroup: institutions
                 <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/sysadmins/system-requirements.html" target="_blank">Read the Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_manage.svg">
                 <h5>Groups and permissions system</h5>
                 <p>Getting to grips with the user roles, groups and permissions in OMERO is a great way to support a range of privacy and collaboration scenarios. This in-depth guide gives you all the information you need.</p>
                 <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/sysadmins/server-permissions.html" target="_blank">Read the Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO server icon" src="{{ site.baseurl }}/img/icons/omero-features-icons_server.svg">
                 <h5>Installing OMERO.server</h5>
                 <p>How to guides are provided for installing the server on a range of supported platforms and this page also links to information for getting your data repository, PostgreSQL database and OMERO.web deployment up and running.</p>
                 <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/sysadmins/unix/index.html" target="_blank">Read the Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO import icon" src="{{ site.baseurl }}/img/icons/omero-features-icons_import.svg">
                 <h5>Advanced import scenarios</h5>
                 <p>This guide provides an overview of the advantages and disadvantages of all the available methods for importing data so you can choose the most appropriate for your facility and put workflows in place for your users.</p>
                 <a class="button hollow tiny expanded" href="https://www.openmicroscopy.org/site/support/omero/sysadmins/import-scenarios.html" target="_blank">Read the Guide</a>

--- a/products/omero/scientists/docs.html
+++ b/products/omero/scientists/docs.html
@@ -13,13 +13,13 @@ usergroup: scientists
         <div class="row small-up-2 large-up-2 text-center">
             <div class="column">
                 <h4>User guides</h4>
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                <i class="fa fa-life-ring fa-4x"></i>
                 <p>‘How to’ guides for common workflows illustrated with extensive screenshots</p>
                 <a href="http://help.openmicroscopy.org" target="_blank" class="button">Get Help on OMERO</a>
             </div>
             <div class="column">
                 <h4>OMERO Documentation</h4>
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                <img class="thumbnail logomark" alt="OMERO logo" src="{{ site.baseurl }}/img/logos/omero-logomark.svg">
                 <p>An overview of OMERO and documentation for the Command Line Interface</p>
                 <a href="https://www.openmicroscopy.org/site/support/omero/users/index.html" target="_blank" class="button">Read the Docs</a>
             </div>

--- a/products/omero/scientists/getting-started.html
+++ b/products/omero/scientists/getting-started.html
@@ -25,13 +25,13 @@ usergroup: scientists
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/getting-started-5.html" target="_blank">Read the Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO.web icon" src="{{ site.baseurl }}/img/icons/omero-features-icons_omero-web.svg">
                 <h5>Using OMERO.web</h5>
                 <p>This guide introduces the browser-based web app and provides an overview of using it to view, organize and share data.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/web-client.html" target="_blank"    >Read the Guide</a>
             </div>
             <div class="column text-center">
-                <img class="thumbnail" src="http://placehold.it/300x150" alt="Liza to illustrate">
+                <img class="thumbnail omero-feature" alt="OMERO FIJI icon" src="{{ site.baseurl }}/img/icons/omero-features-icons_fiji.png">
                 <h5>Using ImageJ/Fiji with OMERO</h5>
                 <p>Already familiar with ImageJ/Fiji for image analysis? This guide gets you set up with the OMERO.insight-ij plugin so you can work with your data stored in OMERO.</p>
                 <a class="button hollow tiny expanded" href="http://help.openmicroscopy.org/imagej.html" target="_blank">Read the Guide</a>


### PR DESCRIPTION
Re-uses images @lunson has already added for the OMERO product user group doc pages and getting started for scientists and institutions.

Staged at 
https://snoopycrimecop.github.io/www.openmicroscopy.org/products/omero/scientists/getting-started.html
https://snoopycrimecop.github.io/www.openmicroscopy.org/products/omero/scientists/docs.html
https://snoopycrimecop.github.io/www.openmicroscopy.org/products/omero/institution/getting-started.html
https://snoopycrimecop.github.io/www.openmicroscopy.org/products/omero/institution/docs.html
and
https://snoopycrimecop.github.io/www.openmicroscopy.org/products/omero/developers/docs.html

Still some further icons needed for the getting started sections and I'm not sure if you want to tweak the docs icons @lunson as the one I re-used for the help guides doesn't match the product logos I've used for the main docs - you should feel free to change stuff if it wasn't what you had in mind.