### PR TITLE
Fix broken internal links

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -16,7 +16,7 @@ title: About Us
         <div class="row column text-center">
             <h2>The Open Microscopy Environment</h2>        
         <hr>
-            <p>We are a multi-site collaborative effort among academic laboratories and a number of commercial entities. We produce open tools to support data management for microscopy. Designed to interact with existing commercial software, all OME formats and software are free, and all OME source code is available under the GNU General public license or more permissive open source licenses, or through commercial license from <a href="commercial-partners.html">Glencoe Software</a>.</p>
+            <p>We are a multi-site collaborative effort among academic laboratories and a number of commercial entities. We produce open tools to support data management for microscopy. Designed to interact with existing commercial software, all OME formats and software are free, and all OME source code is available under the GNU General public license or more permissive open source licenses, or through commercial license from <a href="{{ site.baseurl }}/about/commercial-partners/">Glencoe Software</a>.</p>
         </div>
         <hr class="whitespace">
         <div class="row text-center">
@@ -110,7 +110,7 @@ title: About Us
         </div>
         <hr>
         <div class="row medium-up-1 large-up-1 text-center consortium-list">
-            <div class="large-expand columns"><a href="teams.html#swedlow-lab">Prof Jason Swedlow</a> <span class="institution">Wellcome Trust Centre for Gene Regulation &amp; Expression, Dundee</span></div>            
+            <div class="large-expand columns"><a href="{{ site.baseurl }}/about/teams/index.html#swedlow-lab">Prof Jason Swedlow</a> <span class="institution">Wellcome Trust Centre for Gene Regulation &amp; Expression, Dundee</span></div>
             <div class="large-expand columns"><a target="_blank" href="http://www.hgu.mrc.ac.uk/people/r.baldock.html">Prof Richard Baldock</a> <span class="institution">MRC Human Genetics Unit, Edinburgh</span></div>
             <div class="large-expand columns"><a target="_blank" href="http://www.gen.cam.ac.uk/research-groups/carazo-salas">Prof Rafael Carazo Salas</a> <span class="institution">University of Cambridge</span></div>
             <div class="large-expand columns"><a target="_blank" href="http://www.ebi.ac.uk/about/people/alvis-brazma">Dr Alvis Brazma</a> <span class="institution">European Bioinformatics Institute, Cambridge</span></div>

--- a/products/bio-formats/index.html
+++ b/products/bio-formats/index.html
@@ -34,7 +34,7 @@ title: Bio-Formats
         </div>
         <hr>
         <div class="row column text-center">
-            <p>Bio-Formats is developed by the Open Microscopy Environment consortium, including development teams at <a href="https://loci.wisc.edu/" target="_blank">LOCI at the University of Wisconsin-Madison</a>, <a href="teams.html#swedlow-lab">University of Dundee</a> and <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a>. Licensing and citing information is on the <a href="{{ site.baseurl }}/about/licensing/">OME licensing page</a>.</p>
+            <p>Bio-Formats is developed by the Open Microscopy Environment consortium, including development teams at <a href="https://loci.wisc.edu/" target="_blank">LOCI at the University of Wisconsin-Madison</a>, <a href="{{ site.baseurl }}/about/teams/index.html#swedlow-lab">University of Dundee</a> and <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a>. Licensing and citing information is on the <a href="{{ site.baseurl }}/about/licensing/">OME licensing page</a>.</p>
         </div>
         <!-- end -->
         

--- a/products/ome-files/index.html
+++ b/products/ome-files/index.html
@@ -27,7 +27,7 @@ title: OME Files
         </div>
         <hr>
         <div class="row column text-center">
-            <p>OME Files is a reimplementation of the Bio-Formats Java API, providing equivalent data model, metadata and reading and writing interfaces. Unlike the <a href="bio-formats.html">Bio-Formats</a> Java API, which supports reading of over 140 file formats and writing of over 15 file formats, OME Files restricts itself to reading and writing OME-TIFF and plain TIFF, and does not yet support additional formats. At present it is a reference implementation for the OME-TIFF format, and the focus for development is upon improving and extending the data model metadata APIs and the reader and writer APIs, rather than adding additional formats.</p>
+            <p>OME Files is a reimplementation of the Bio-Formats Java API, providing equivalent data model, metadata and reading and writing interfaces. Unlike the <a href="{{ site.baseurl }}/products/bio-formats/">Bio-Formats</a> Java API, which supports reading of over 140 file formats and writing of over 15 file formats, OME Files restricts itself to reading and writing OME-TIFF and plain TIFF, and does not yet support additional formats. At present it is a reference implementation for the OME-TIFF format, and the focus for development is upon improving and extending the data model metadata APIs and the reader and writer APIs, rather than adding additional formats.</p>
         </div>
         <!-- end -->
         


### PR DESCRIPTION
To review this PR, review the output of the `htmlproofer` in the Travis log, check the number of failures decreased and make sure there are no more errors of type

```
internally linking to xxx, which does not exist
```