### PR TITLE
Comment out imaging domains & remove unneeded link

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -150,7 +150,7 @@ title: About Us
             <div class="large-expand columns"><a target="_blank" href="http://www.bitplane.com/">Bitplane’s Imaris</a></div>
         </div>
         <div class="row text-center">
-            <a href="#" class="button expanded">Link to Exhaustive List</a>
+            <p>And many others!</p>
         </div>
         <hr class="whitespace">
         <div class="row"><p class="text-center">Places that publish image data with OMERO and Bio-Formats:</p></div>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ title: Home
             </div>
             <!-- end OME Files highlight -->
         
-        <!-- begin Imaging highlight -->
+        <!-- begin Imaging highlight>
         <hr class="whitespace">        
         <div class="row column text-center">
             <h2>Imaging Domains</h2>
@@ -67,7 +67,7 @@ title: Home
                 <a href="#" class="button small center">Learn More</a>
             </div>
         </div>
-        <!-- end Big Image highlight -->
+        <end Big Image highlight -->
         
         <!-- begin Sites Powered by OME Technology -->
         <hr class="whitespace">        


### PR DESCRIPTION
More tidying ready for the POTN preview - commented out the imaging domains section on the home page (not a priority right now to generate further content for this) and removed the unneeded link from the examples of OME resource use in external projects - when I checked back this list, we already included all the items on the current live website page so no extension was needed.