### PR TITLE
Revert allowing html proofer to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ env:
 install: bundle install
 script:
     - bundle exec jekyll build  -d _site/www.openmicroscopy.org
-    - bundle exec htmlproofer ./_site --disable-external || echo "Failed"
+    - bundle exec htmlproofer ./_site --disable-external


### PR DESCRIPTION
As suggested on #21 this makes the html proofer failing fail Travis too now all the errors are fixed.