### PR TITLE
Update contributors list

### DIFF
--- a/about/contributors/index.html
+++ b/about/contributors/index.html
@@ -105,7 +105,7 @@ title: Contributors
             </div>
             
             <div class="large-expand columns">
-            Mark Bruce <a target="_blank" href="https://www.microvolution.com">Microvolution LLC</a>
+            Marc Bruce <a target="_blank" href="https://www.microvolution.com">Microvolution LLC</a>
             </div>
             
             <div class="large-expand columns">

--- a/about/contributors/index.html
+++ b/about/contributors/index.html
@@ -41,6 +41,10 @@ title: Contributors
             </div>
             
             <div class="large-expand columns">
+            Daniel Matthews <a target="_blank" href="http://nic.kcl.ac.uk">Nikon Imaging Centre, Kings College London</a> <a target="_blank" href="https://qbi.uq.edu.au">(formerly Queensland Brain Institute)</a>
+            </div>
+            
+            <div class="large-expand columns">
             David Pinto <a target="_blank" href="http://www.bioch.ox.ac.uk">Department of Biochemistry, University of Oxford</a>
             </div>
             
@@ -101,6 +105,10 @@ title: Contributors
             </div>
             
             <div class="large-expand columns">
+            Mark Bruce <a target="_blank" href="https://www.microvolution.com">Microvolution LLC</a>
+            </div>
+            
+            <div class="large-expand columns">
             Gerhard Burger <a target="_blank" href="http://www.universiteitleiden.nl/en">Leiden University</a>
             </div>
             
@@ -150,6 +158,10 @@ title: Contributors
             
             <div class="large-expand columns">
             Aivar Grislis <a target="_blank" href="http://loci.wisc.edu/people/aivar-grislis">UW-Madison LOCI</a>
+            </div>
+            
+            <div class="large-expand columns">
+            Michael Goelzer <a target="_blank" href="http://www.leica-microsystems.com/home/">Leica Microsystems</a>
             </div>
             
             <div class="large-expand columns">
@@ -265,6 +277,10 @@ title: Contributors
             </div>
             
             <div class="large-expand columns">
+            Christian Sachs <a target="_blank" href="http://www.fz-juelich.de/ibg/ibg-1/EN/Home/home_node.html"> Institute of Bio- and Geosciences, Jülich</a>
+            </div>
+            
+            <div class="large-expand columns">
             Johannes Schindelin <a target="_blank" href="http://loci.wisc.edu/people/johannes-schindelin">UW-Madison LOCI</a>, <a target="_blank" href="http://fiji.sc/">Fiji Project</a>, <a target="_blank" href="http://www.mpi-cbg.de/">Max-Planck Institute of Molecular Cell Biology in Dresden</a>
             </div>
             
@@ -278,6 +294,14 @@ title: Contributors
             
             <div class="large-expand columns">
             Christoph Sommer <a target="_blank" href="http://imba.oeaw.ac.at">Institute of Molecular Biotechnology</a>
+            </div>
+            
+            <div class="large-expand columns">
+            Torsten Stöter <a target="_blank" href="http://www.lin-magdeburg.de">Leibniz Institute for Neurobiology</a>
+            </div>
+            
+            <div class="large-expand columns">
+            Manuel Stritt <a target="_blank" href="https://www.actelion.com"> Actelion Pharmaceuticals Ltd</a>
             </div>
             
             <div class="large-expand columns">


### PR DESCRIPTION
A few folks have been added to https://www.openmicroscopy.org/site/about/ome-contributors since this content was copied over originally.

Staged at https://snoopycrimecop.github.io/www.openmicroscopy.org/about/contributors/