### PR TITLE
User meeting 2017 page content

### DIFF
--- a/community/events/12th-annual-users-meeting-2017.html
+++ b/community/events/12th-annual-users-meeting-2017.html
@@ -1,7 +1,7 @@
 ---
 layout: community-events
 title: 12th Annual Users Meeting 2017
-main-blurb: The 12th Annual OME Users Meeting will be held at the University of Dundee on May 31st to June 2nd 2017.
+main-blurb: The 12th Annual OME Users Meeting was held at the University of Dundee on May 31st to June 2nd 2017.
 ---          
                 
         <!-- begin Events -->
@@ -36,6 +36,126 @@ main-blurb: The 12th Annual OME Users Meeting will be held at the University of 
                 <h4 class="event-speaker">Chris Allan, Glencoe Software</h4>
             </div>
         </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:00 - 13:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Lunch</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">13:00 - 13:10</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Welcome</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">13:10 - 13:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title"><a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Talks/Swedlow_OME_UsersMtg_May2017_v2.pdf" target="_blank">OME Project Summary and Progress</h3>
+                <h4 class="event-speaker">Jason Swedlow, OME</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">13:45 - 14:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Machine Learning-based Whole Slide Analysis with Orbit</h3>
+                <h4 class="event-speaker">Manuel Stritt, Actelion Pharmaceuticals Ltd</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:15 - 14:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Molecular profiling of adverse skin reactions to cancer immunotherapy</h3>
+                <h4 class="event-speaker">Zoltan Maliga, Harvard Medical School</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:45 - 15:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title"><a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Talks/Russell_OMERO-in-the-Cloud.pdf" target="_blank">OMERO in the Cloud: A BD2K Project</h3>
+                <h4 class="event-speaker">Douglas Russell, Harvard Medical School</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">15:15 - 15:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Tea/coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">15:45 - 16:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">PLoS Data Policy</h3>
+                <h4 class="event-speaker">Emma Ganley, PLoS</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">16:15 - 16:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title"><a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Talks/Moore+Williams_ImageDataResource.pdf" target="_blank">The Image Data Resource: Working with Linked Datasets</h3>
+                <h4 class="event-speaker">Josh Moore and Eleanor Williams, OME</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">16:45 - 17:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">SSBD: Systems Science of Biological Dynamics Database</h3>
+                <h4 class="event-speaker">Shuichi Onami, RIKEN</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">17:15 - 17:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title"><a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Talks/Masuzzo_ome-2017.pdf" target="_blank">Towards open data in cell migration research</h3>
+                <h4 class="event-speaker">Paola Masuzzo, University of Ghent</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">17:45 - 18:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title"><a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Posters/" target="_blank">One minute poster talks</a></h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">18:00 - 19:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Poster session with refreshments</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">19.00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Dinner</h3>
+            </div>
+        </div>
         
         <hr class="whitespace">
         <div class="row">        
@@ -68,19 +188,200 @@ main-blurb: The 12th Annual OME Users Meeting will be held at the University of 
                 <h3 class="event-title">Workshops - Round 1</h3>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 1</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Using-OMERO/Using-OMERO-Workshop-Outline.pdf">Using OMERO</a></li>
-                    <li>Informal demonstrations of OMERO.clients, especially OMERO.web</li>
-                    <li>Informal demonstrations of web apps: figure, iviewer, webtagging etc.</li>
-                    <li>Informal demonstrations of other tools developed by the OME consortium e.g. mtools, ImageJ</li>
-                    <li>Discussions as requested on integrating your own tools: Java, Python etc.</li>
-                    <li>Discussions as requested on using/customizing training materials</li>
+                    <li>
+                        Informal demonstrations of OMERO.clients, especially
+                        OMERO.web
+                    </li>
+                    <li>
+                        Informal demonstrations of web apps: figure, iviewer,
+                        webtagging etc.
+                    </li>
+                    <li>
+                        Informal demonstrations of other tools developed by
+                        the OME consortium e.g. mtools, ImageJ
+                    </li>
+                    <li>
+                        Discussions as requested on integrating your own
+                        tools: Java, Python etc.
+                    </li>
+                    <li>
+                        Discussions as requested on using/customizing training
+                        materials
+                    </li>
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 2</span> - Working with OME Files and Bio-Formats (developer-aimed session)</li>
-                    <li>Overview of OME Model and Formats, Bio-Formats and OME Files</li>
-                    <li><a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Introduction-to-Bio-Formats/#/">Introduction to working with Bio-Formats</a></li>
-                    <li><a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/OME-Files-C++/cpp-dundee-2017.pdf">Introduction to working with OME Files</a></li>
+                    <li>
+                        Overview of OME Model and Formats, Bio-Formats and OME 
+                        Files
+                    </li>
+                    <li>
+                        <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Introduction-to-Bio-Formats/#/">Introduction to working with Bio-Formats</a>
+                    </li>
+                    <li>
+                        <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/OME-Files-C++/cpp-dundee-2017.pdf">Introduction to working with OME Files</a>
+                    </li>
                     <li>Small group breakout sessions</li>
-                </ul>                    
+                </ul>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title"><span class="event-workshop-room">Room 3</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/IDR_Annotations_Tour_Workshop_2017.pdf">IDR annotations tour</a> (please bring laptop)</li>
+                    <li>
+                        Search for annotations in the IDR web user interface
+                    </li>
+                    <li>
+                        Query and retrieve annotations using the web API
+                    </li>
+                    <li>
+                        Annotation querying and analysis using Jupyter
+                        notebooks
+                    </li>
+                    <li>
+                        Annotating your own images in OMERO (if time allows)
+                    </li>
+                </ul>                 
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:45 - 11:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Tea/coffee &amp; refreshments</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:15 - 12:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Workshops - Round 2</h3>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title"><span class="event-workshop-room">Room 1</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Engineering-OMERO-IDR/#/">OMERO DevOps / OMERO @scale</a></li>
+                    <li>
+                        Introduction to OMERO @Scale
+                    </li>
+                    <li>
+                        Tools for configuration, testing and deployment
+                        management (e.g. Docker)
+                    </li>
+                    <li>
+                        Image Data Resource (IDR) case study (OpenStack, GPFS,
+                        public web, caching)
+                    </li>
+                </ul>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title"><span class="event-workshop-room">Room 2</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Import/#/">Import CLI</a></li>
+                    <li>
+                        CLI import: advanced import and extensible import
+                    </li>
+                    <li>
+                        Import options review, Import As
+                    </li>
+                    <li>
+                        <a href="http://c0c0n3.github.io/ome-smuggler/docs/content/examples/whirlwind-tour.html">OME.smuggler</a>: queue your imports (w/ Andrea Falconi, Montpellier)
+                    </li>
+                </ul>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title"><span class="event-workshop-room">Room 3</span> - <a href="https://www.upf.edu/documents/4181972/7974943/Rocket%40OME2017/3d9cebf8-2c95-5952-c458-cc4f9908756d">Rocket</a>: a flexible, modular, cloud-based platform for the management of heterogeneous information from acquisitions and tools for biomedical research (Chong Zhang, Neubias)</li>
+                    <li>
+                        Introduction about the Rocket platform design
+                        architecture and technology
+                    </li>
+                    <li>
+                        Use cases: 1. collaborative clinical data manager 2.
+                        bioimage analysis task manager
+                    </li>
+                    <li>
+                        Demo and play
+                    </li>
+                </ul>                 
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:30 - 13:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Lunch</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">13:45 - 15:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Workshops - Round 3</h3>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title"><span class="event-workshop-room">Room 1</span> - <a href="https://gist.github.com/dpwrussell/48ae4036d34ef88797a22331ccebdc86">OMERO for AWS</a> (Douglas Russell, Harvard)</li>
+                    <li>
+                        Introduction to Docker and AWS
+                    </li>
+                    <li>
+                        Building archives locally with Docker
+                    </li>
+                    <li>
+                        Dehydrating an archive to S3
+                    </li>
+                    <li>
+                        Hydrating an archive in AWS with Cloudformation
+                    </li>
+                </ul>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title"><span class="event-workshop-room">Room 2</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Jupyter-Workshops/">Analyzing data in OMERO</a></li>
+                    <li>
+                        Introduction to IDR and Jupyter
+                    </li>
+                    <li>
+                        Analyzing data in OMERO using Python and R
+                    </li>
+                    <li>
+                        Working through use-cases including image features
+                    </li>
+                </ul>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title"><span class="event-workshop-room">Room 3</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Omero-Web/#/">OMERO.web apps</a></li>
+                    <li>
+                        Intro to OMERO.web framework
+                    </li>
+                    <li>
+                        new JSON API
+                    </li>
+                    <li>
+                        App overview: figure, iviewer, mapr, etc.
+                    </li>
+                    <li>
+                        Available extension points
+                    </li>
+                </ul>                 
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">15:00 - 15:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Tea/coffee &amp; refreshments</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">15:30 - 16:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Workshops - Round 4</h3>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title"><span class="event-workshop-room">Room 1</span> - Resources for devs</li>
+                    <li class="event-workshop-title"><span class="event-workshop-room">Room 2</span> - Workshop re-runs as requested</li>
+                    <li class="event-workshop-title"><span class="event-workshop-room">Room 3</span> - Workshop re-runs as requested</li>
+                </ul>                 
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">17.00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Wine tasting and buffet dinner</h3>
             </div>
         </div>
         

--- a/community/events/12th-annual-users-meeting-2017.html
+++ b/community/events/12th-annual-users-meeting-2017.html
@@ -188,56 +188,34 @@ main-blurb: The 12th Annual OME Users Meeting was held at the University of Dund
                 <h3 class="event-title">Workshops - Round 1</h3>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 1</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Using-OMERO/Using-OMERO-Workshop-Outline.pdf">Using OMERO</a></li>
-                    <li>
-                        Informal demonstrations of OMERO.clients, especially
-                        OMERO.web
-                    </li>
-                    <li>
-                        Informal demonstrations of web apps: figure, iviewer,
-                        webtagging etc.
-                    </li>
-                    <li>
-                        Informal demonstrations of other tools developed by
-                        the OME consortium e.g. mtools, ImageJ
-                    </li>
-                    <li>
-                        Discussions as requested on integrating your own
-                        tools: Java, Python etc.
-                    </li>
-                    <li>
-                        Discussions as requested on using/customizing training
-                        materials
-                    </li>
+                    <li>Informal demonstrations of OMERO.clients, especially
+                        OMERO.web</li>
+                    <li>Informal demonstrations of web apps: figure, iviewer,
+                        webtagging etc.</li>
+                    <li>Informal demonstrations of other tools developed by
+                        the OME consortium e.g. mtools, ImageJ</li>
+                    <li>Discussions as requested on integrating your own
+                        tools: Java, Python etc.</li>
+                    <li>Discussions as requested on using/customizing training
+                        materials</li>
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 2</span> - Working with OME Files and Bio-Formats (developer-aimed session)</li>
-                    <li>
-                        Overview of OME Model and Formats, Bio-Formats and OME 
-                        Files
-                    </li>
-                    <li>
-                        <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Introduction-to-Bio-Formats/#/">Introduction to working with Bio-Formats</a>
-                    </li>
-                    <li>
-                        <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/OME-Files-C++/cpp-dundee-2017.pdf">Introduction to working with OME Files</a>
-                    </li>
+                    <li>Overview of OME Model and Formats, Bio-Formats and OME 
+                        Files</li>
+                    <li><a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Introduction-to-Bio-Formats/#/">Introduction to working with Bio-Formats</a></li>
+                    <li><a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/OME-Files-C++/cpp-dundee-2017.pdf">Introduction to working with OME Files</a></li>
                     <li>Small group breakout sessions</li>
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 3</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/IDR_Annotations_Tour_Workshop_2017.pdf">IDR annotations tour</a> (please bring laptop)</li>
-                    <li>
-                        Search for annotations in the IDR web user interface
-                    </li>
-                    <li>
-                        Query and retrieve annotations using the web API
-                    </li>
-                    <li>
-                        Annotation querying and analysis using Jupyter
-                        notebooks
-                    </li>
-                    <li>
-                        Annotating your own images in OMERO (if time allows)
-                    </li>
+                    <li>Search for annotations in the IDR web user 
+                        interface</li>
+                    <li>Query and retrieve annotations using the web API</li>
+                    <li>Annotation querying and analysis using Jupyter
+                        notebooks</li>
+                    <li>Annotating your own images in OMERO (if time 
+                        allows)</li>
                 </ul>                 
             </div>
         </div>
@@ -257,43 +235,26 @@ main-blurb: The 12th Annual OME Users Meeting was held at the University of Dund
                 <h3 class="event-title">Workshops - Round 2</h3>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 1</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Engineering-OMERO-IDR/#/">OMERO DevOps / OMERO @scale</a></li>
-                    <li>
-                        Introduction to OMERO @Scale
-                    </li>
-                    <li>
-                        Tools for configuration, testing and deployment
-                        management (e.g. Docker)
-                    </li>
-                    <li>
-                        Image Data Resource (IDR) case study (OpenStack, GPFS,
-                        public web, caching)
-                    </li>
+                    <li>Introduction to OMERO @Scale</li>
+                    <li>Tools for configuration, testing and deployment
+                        management (e.g. Docker)</li>
+                    <li>Image Data Resource (IDR) case study (OpenStack, GPFS,
+                        public web, caching)</li>
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 2</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Import/#/">Import CLI</a></li>
-                    <li>
-                        CLI import: advanced import and extensible import
-                    </li>
-                    <li>
-                        Import options review, Import As
-                    </li>
-                    <li>
-                        <a href="http://c0c0n3.github.io/ome-smuggler/docs/content/examples/whirlwind-tour.html">OME.smuggler</a>: queue your imports (w/ Andrea Falconi, Montpellier)
-                    </li>
+                    <li>CLI import: advanced import and extensible import</li>
+                    <li>Import options review, Import As</li>
+                    <li><a href="http://c0c0n3.github.io/ome-smuggler/docs/content/examples/whirlwind-tour.html">OME.smuggler</a>: queue your imports (w/ Andrea Falconi, 
+                        Montpellier)</li>
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 3</span> - <a href="https://www.upf.edu/documents/4181972/7974943/Rocket%40OME2017/3d9cebf8-2c95-5952-c458-cc4f9908756d">Rocket</a>: a flexible, modular, cloud-based platform for the management of heterogeneous information from acquisitions and tools for biomedical research (Chong Zhang, Neubias)</li>
-                    <li>
-                        Introduction about the Rocket platform design
-                        architecture and technology
-                    </li>
-                    <li>
-                        Use cases: 1. collaborative clinical data manager 2.
-                        bioimage analysis task manager
-                    </li>
-                    <li>
-                        Demo and play
-                    </li>
+                    <li>Introduction about the Rocket platform design
+                        architecture and technology</li>
+                    <li>Use cases: 1. collaborative clinical data manager 2.
+                        bioimage analysis task manager</li>
+                    <li>Demo and play</li>
                 </ul>                 
             </div>
         </div>
@@ -313,45 +274,24 @@ main-blurb: The 12th Annual OME Users Meeting was held at the University of Dund
                 <h3 class="event-title">Workshops - Round 3</h3>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 1</span> - <a href="https://gist.github.com/dpwrussell/48ae4036d34ef88797a22331ccebdc86">OMERO for AWS</a> (Douglas Russell, Harvard)</li>
-                    <li>
-                        Introduction to Docker and AWS
-                    </li>
-                    <li>
-                        Building archives locally with Docker
-                    </li>
-                    <li>
-                        Dehydrating an archive to S3
-                    </li>
-                    <li>
-                        Hydrating an archive in AWS with Cloudformation
-                    </li>
+                    <li>Introduction to Docker and AWS</li>
+                    <li>Building archives locally with Docker</li>
+                    <li>Dehydrating an archive to S3</li>
+                    <li>Hydrating an archive in AWS with Cloudformation</li>
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 2</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Jupyter-Workshops/">Analyzing data in OMERO</a></li>
-                    <li>
-                        Introduction to IDR and Jupyter
-                    </li>
-                    <li>
-                        Analyzing data in OMERO using Python and R
-                    </li>
-                    <li>
-                        Working through use-cases including image features
-                    </li>
+                    <li>Introduction to IDR and Jupyter</li>
+                    <li>Analyzing data in OMERO using Python and R</li>
+                    <li>Working through use-cases including image 
+                        features</li>
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 3</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Omero-Web/#/">OMERO.web apps</a></li>
-                    <li>
-                        Intro to OMERO.web framework
-                    </li>
-                    <li>
-                        new JSON API
-                    </li>
-                    <li>
-                        App overview: figure, iviewer, mapr, etc.
-                    </li>
-                    <li>
-                        Available extension points
-                    </li>
+                    <li>Intro to OMERO.web framework</li>
+                    <li>new JSON API</li>
+                    <li>App overview: figure, iviewer, mapr, etc.</li>
+                    <li>Available extension points</li>
                 </ul>                 
             </div>
         </div>

--- a/community/events/12th-annual-users-meeting-2017.html
+++ b/community/events/12th-annual-users-meeting-2017.html
@@ -289,7 +289,7 @@ main-blurb: The 12th Annual OME Users Meeting was held at the University of Dund
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 3</span> - <a href="http://downloads.openmicroscopy.org/presentations/2017/Users-Meeting/Workshops/Omero-Web/#/">OMERO.web apps</a></li>
                     <li>Intro to OMERO.web framework</li>
-                    <li>new JSON API</li>
+                    <li>New JSON API</li>
                     <li>App overview: figure, iviewer, mapr, etc.</li>
                     <li>Available extension points</li>
                 </ul>                 

--- a/community/events/index.html
+++ b/community/events/index.html
@@ -11,7 +11,7 @@ main-blurb: Meet the OME team in person
             <div class="small-12 medium-8 medium-offset-2 columns">
                 <h6><i class="fa fa-calendar"></i> May 31 - June 2, 2017</h6>
                 <h2><a href="{{ site.baseurl }}/community/events/12th-annual-users-meeting-2017.html">12th Annual Users Meeting 2017</a></h2>
-                <p class="card-caption">The 12th Annual OME Users Meeting will be held at the University of Dundee on May 31st to June 2nd 2017.</p>
+                <p class="card-caption">The 12th Annual OME Users Meeting was held at the University of Dundee on May 31st to June 2nd 2017.</p>
             </div>
             <hr class="medium-8">
 
@@ -20,7 +20,7 @@ main-blurb: Meet the OME team in person
         <hr class="whitespace">
         <div class="row">
             <div class="small-12 medium-8 medium-offset-2">
-                <p class="callout primary">[ Hi Helen - please help with this wording. ] We are working to get the rest of the Previous Users Meeting Notes up. In the meantime, previous notes can be found here [insert link].</p>
+                <p class="callout primary">We are in the process of moving content to this new site at present. Details of earlier meetings are still available at [https://www.openmicroscopy.org/site/community/minutes/meetings] </p>
             </div>
         </div>       
         <hr class="invisible">


### PR DESCRIPTION
Completes the content on https://snoopycrimecop.github.io/www.openmicroscopy.org/community/events/12th-annual-users-meeting-2017.html which should now match https://www.openmicroscopy.org/site/community/minutes/meetings/12th-annual-users-meeting-2017