### PR TITLE
Move product versions and build numbers to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,26 @@ name: OME  Website
 markdown: kramdown
 
 baseurl: /www.openmicroscopy.org
+
+bf:
+ version: 5.5.2
+
+omero:
+ version: 5.3.2
+ build: b62
+
+omecommoncpp:
+  version: 5.4.0
+
+omemodel:
+  version: 5.5.1
+
+omeqtwidgets:
+ version: 5.4.0
+ 
+omefiles:
+ version: 0.3.2
+ build: 22
+
+omecmakesuperbuild:
+ version: 0.3.2

--- a/_config.yml
+++ b/_config.yml
@@ -7,8 +7,8 @@ bf:
  version: 5.5.2
 
 omero:
- version: 5.3.2
- build: b62
+ version: 5.3.3
+ build: b63
 
 omecommoncpp:
   version: 5.4.0

--- a/products/bio-formats/downloads/index.html
+++ b/products/bio-formats/downloads/index.html
@@ -4,7 +4,7 @@ title: Bio-Formats Downloads
 ---     
         <div class="callout large primary" id="bg-image-bio-formats">
             <div class="row column text-center">
-                <h1>Bio-Formats 5.5.0 Downloads</h1>
+                <h1>Bio-Formats {{ site.bf.version }} Downloads</h1>
             </div>
         </div>
         
@@ -20,7 +20,7 @@ title: Bio-Formats Downloads
                         <h5>Bio-Formats Package</h5>
                         <h6>bioformats_package.jar</h6>
                         <p class="card-caption">The complete bundle for end users containing everything needed to read images into ImageJ. Instructions for installing Bio-Formats in ImageJ are available in the <a href="http://www.openmicroscopy.org/site/support/bio-formats/users/imagej/installing.html" taget="_blank">user guide</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/5.5.0/artifacts/bioformats_package.jar" class="button hollow small"><i class="fa fa-download"></i> Download (31.64 MB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats_package.jar" class="button hollow small"><i class="fa fa-download"></i> Download (31.64 MB)</a>
                     </div>
                 </div>
             </div>
@@ -31,7 +31,7 @@ title: Bio-Formats Downloads
                         <h5>Command Line Tools</h5>
                         <h6>bftools.zip</h6>
                         <p class="card-caption">A bundle of scripts for using Bio-Formats on the command line with bioformats_package.jar already included. For more info, see the <a href="http://www.openmicroscopy.org/site/support/bio-formats/users/comlinetools/index.html" target="_blank">command line tools documentation</a>.</p>
-                        <a href="http://downloads.openmicroscopy.org/bio-formats/5.5.0/artifacts/bftools.zip" class="button hollow small"><i class="fa fa-download"></i> Download (29.96 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bftools.zip" class="button hollow small"><i class="fa fa-download"></i> Download (29.96 MB)</a>
                     </div>
                 </div>
             </div>
@@ -42,7 +42,7 @@ title: Bio-Formats Downloads
                         <h5>MATLAB Toolbox</h5>
                         <h6>bfmatlab.zip</h6>
                         <p class="card-caption">A bundle of functions for using Bio-Formats from MATLAB with bioformats_package.jar already included. For more info, see the <a href="http://www.openmicroscopy.org/site/support/bio-formats/users/matlab/index.html" target="_blank">MATLAB documentation</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/5.5.0/artifacts/bfmatlab.zip" class="button hollow small"><i class="fa fa-download"></i> Download (29.97 MB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bfmatlab.zip" class="button hollow small"><i class="fa fa-download"></i> Download (29.97 MB)</a>
                     </div>
                 </div>
             </div>
@@ -51,9 +51,9 @@ title: Bio-Formats Downloads
                     <div class="card-section">
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_octave.png">
                         <h5>Octave Package</h5>
-                        <h6>bioformats-octave-5.5.0.tar.gz</h6>
+                        <h6>bioformats-octave-{{ site.bf.version }}.tar.gz</h6>
                         <p class="card-caption">A bundle of functions for using Bio-Formats from Octave. You’ll need to install bioformats_package.jar separately. For more info, see the <a href="http://www.openmicroscopy.org/site/support/bio-formats/users/octave/index.html" target="_blank">Octave documentation</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/5.5.0/artifacts/bioformats-octave-5.5.0.tar.gz" class="button hollow small"><i class="fa fa-download"></i> Download (37.44 KB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-octave-{{ site.bf.version }}.tar.gz" class="button hollow small"><i class="fa fa-download"></i> Download (37.44 KB)</a>
                     </div>
                 </div>
             </div>
@@ -69,9 +69,9 @@ title: Bio-Formats Downloads
                     <div class="card-section">
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_public-api.svg">
                         <h5>API Documentation</h5>
-                        <h6>bio-formats-javadocs-5.5.0.zip</h6>
-                        <p class="card-caption">The Javadoc bundle containing the Bio-Formats API documentation is <a href="https://downloads.openmicroscopy.org/bio-formats/5.5.0/api">here</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/5.5.0/artifacts/bio-formats-javadocs-5.5.0.zip" class="button hollow small"><i class="fa fa-download"></i> Download (14.7 MB)</a>
+                        <h6>bio-formats-javadocs-{{ site.bf.version }}.zip</h6>
+                        <p class="card-caption">The Javadoc bundle containing the Bio-Formats API documentation is <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/api">here</a>.</p>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bio-formats-javadocs-{{ site.bf.version }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (14.7 MB)</a>
                     </div>
                 </div>
             </div>
@@ -80,9 +80,9 @@ title: Bio-Formats Downloads
                     <div class="card-section">
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_scripts.svg">
                         <h5>Source Code</h5>
-                        <h6>bioformats-5.5.0.tar.xz</h6>
+                        <h6>bioformats-{{ site.bf.version }}.tar.xz</h6>
                         <p></p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/5.5.0/artifacts/bioformats-5.5.0.tar.xz" class="button hollow small"><i class="fa fa-download"></i> Download (9.14 MB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-{{ site.bf.version }}.tar.xz" class="button hollow small"><i class="fa fa-download"></i> Download (9.14 MB)</a>
                         <a href="https://github.com/openmicroscopy/bioformats" target="_blank" class="button hollow small"><i class="fa fa-github"></i> View GitHub Repository</a>
                     </div>
                 </div>
@@ -92,10 +92,10 @@ title: Bio-Formats Downloads
                     <div class="card-section">
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_scripts.svg">
                         <h5>Source Code</h5>
-                        <h6>bioformats-5.5.0.zip</h6>
+                        <h6>bioformats-{{ site.bf.version }}.zip</h6>
                         <p></p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/5.5.0/artifacts/bioformats-5.5.0.zip" class="button hollow small"><i class="fa fa-download"></i> Download (12.67 MB)</a><br>
-                        <a href="https://github.com/openmicroscopy/bioformats/tree/v5.5.0" target="_blank" class="button hollow small"><i class="fa fa-github"></i> View Git Tag</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-{{ site.bf.version }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (12.67 MB)</a><br>
+                        <a href="https://github.com/openmicroscopy/bioformats/tree/v{{ site.bf.version }}" target="_blank" class="button hollow small"><i class="fa fa-github"></i> View Git Tag</a>
                     </div>
                 </div>
             </div>
@@ -111,7 +111,7 @@ title: Bio-Formats Downloads
             <div class="row">
                 <div class="small-12 columns bg-image-text-container-cta text-center">
                     <p class="hero-subheader">All components available for this version of Bio-Formats are available here:</p>
-                    <a href="https://downloads.openmicroscopy.org/bio-formats/5.5.0/artifacts/?C=M;O=D" class="large btn-red button sites-button hide-for-small-only" style="text-shadow: none;">Download Components</a>
+                    <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/?C=M;O=D" class="large btn-red button sites-button hide-for-small-only" style="text-shadow: none;">Download Components</a>
                 </div>
             </div>
         </header>

--- a/products/bio-formats/index.html
+++ b/products/bio-formats/index.html
@@ -8,7 +8,7 @@ title: Bio-Formats
                     <h1 class="hero-main-header"><img src="{{ site.baseurl }}/img/logos/bio-formats-white.svg" alt="Bio-Formats logo" class="logo-hero" /></h1>
                     <p class="hero-subheader small-12">The solution for reading proprietary microscopy image data and metadata</p>
                     <br>
-                    <a href="{{ site.baseurl }}/products/bio-formats/downloads/" class="large button sites-button hide-for-small-only btn-red">Download Version 5.5.0</a>
+                    <a href="{{ site.baseurl }}/products/bio-formats/downloads/" class="large button sites-button hide-for-small-only btn-red">Download Version {{ site.bf.version }}</a>
                 </div>
             </div>
         </header>

--- a/products/ome-files/downloads/index.html
+++ b/products/ome-files/downloads/index.html
@@ -18,8 +18,8 @@ title: OME Files Downloads
                     <div class="card-section">
                         <img alt="CentOS logo" src="{{ site.baseurl }}/img/logos/3rd-party_centos.png">
                         <h5>CentOS 7.3</h5>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-standalone-bundle-0.3.2-Release-CentOS7.3-x86_64-b22.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Release (28.28 MB)</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-standalone-bundle-0.3.2-Release-CentOS7.3-x86_64-b22.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Debug (54.18 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-standalone-bundle-{{ site.omefiles.version }}-Release-CentOS7.3-x86_64-b{{ site.omefiles.build }}.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Release (28.28 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-standalone-bundle-{{ site.omefiles.version }}-Release-CentOS7.3-x86_64-b{{ site.omefiles.build }}.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Debug (54.18 MB)</a>
                     </div>
                 </div>
             </div>
@@ -28,8 +28,8 @@ title: OME Files Downloads
                     <div class="card-section">
                         <img alt="CentOS logo" src="{{ site.baseurl }}/img/logos/3rd-party_centos.png">
                         <h5>CentOS 6.8</h5>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-standalone-bundle-0.3.2-Release-CentOS6.8-x86_64-b22.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Release (28.37 MB)</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-standalone-bundle-0.3.2-Debug-CentOS6.8-x86_64-b22.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Debug (55.5 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-standalone-bundle-{{ site.omefiles.version }}-Release-CentOS6.8-x86_64-b{{ site.omefiles.build }}.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Release (28.37 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-standalone-bundle-{{ site.omefiles.version }}-Debug-CentOS6.8-x86_64-b{{ site.omefiles.build }}.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Debug (55.5 MB)</a>
                     </div>
                 </div>
             </div>
@@ -38,8 +38,8 @@ title: OME Files Downloads
                     <div class="card-section">
                         <img alt="MacOS X logo" src="{{ site.baseurl }}/img/logos/3rd-party_macosx.jpg">
                         <h5>MacOS X 10.12</h5>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-standalone-bundle-0.3.2-Release-MacOSX10.12.2-x86_64-b22.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Release (25.3 MB)</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-standalone-bundle-0.3.2-Debug-MacOSX10.12.2-x86_64-b22.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Debug (26.86 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-standalone-bundle-{{ site.omefiles.version }}-Release-MacOSX10.12.2-x86_64-b{{ site.omefiles.build }}.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Release (25.3 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-standalone-bundle-{{ site.omefiles.version }}-Debug-MacOSX10.12.2-x86_64-b{{ site.omefiles.build }}.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Debug (26.86 MB)</a>
                     </div>
                 </div>
             </div>
@@ -48,8 +48,8 @@ title: OME Files Downloads
                     <div class="card-section">
                         <img alt="FreeBSD logo" src="{{ site.baseurl }}/img/logos/3rd-party_freebsd.png">
                         <h5>FreeBSD 11.0</h5>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-standalone-bundle-0.3.2-Release-FreeBSD11.0-amd64-b22.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Release (27.62 MB)</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-standalone-bundle-0.3.2-Debug-FreeBSD11.0-amd64-b22.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Debug (54.15 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-standalone-bundle-{{ site.omefiles.version }}-Release-FreeBSD11.0-amd64-b{{ site.omefiles.build }}.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Release (27.62 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-standalone-bundle-{{ site.omefiles.version }}-Debug-FreeBSD11.0-amd64-b{{ site.omefiles.build }}.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Debug (54.15 MB)</a>
                     </div>
                 </div>
             </div>
@@ -58,8 +58,8 @@ title: OME Files Downloads
                     <div class="card-section">
                         <img alt="Ubuntu logo" src="{{ site.baseurl }}/img/logos/3rd-party_ubuntu.png">
                         <h5>Ubuntu 14.04</h5>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-standalone-bundle-0.3.2-Release-FreeBSD11.0-amd64-b22.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Release (28.4 MB)</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-standalone-bundle-0.3.2-Debug-FreeBSD11.0-amd64-b22.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Debug (54.34 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-standalone-bundle-{{ site.omefiles.version }}-Release-FreeBSD11.0-amd64-b{{ site.omefiles.build }}.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Release (28.4 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-standalone-bundle-{{ site.omefiles.version }}-Debug-FreeBSD11.0-amd64-b{{ site.omefiles.build }}.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Debug (54.34 MB)</a>
                     </div>
                 </div>
             </div>
@@ -70,8 +70,8 @@ title: OME Files Downloads
                     <div class="card-section">
                         <img alt="Windows logo" src="{{ site.baseurl }}/img/logos/3rd-party_windows.png">
                         <h5>Windows VC12 64‑bit (VS2013)</h5>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-bundle-0.3.2-VC12-x64-Release-b22.zip" class="button hollow tiny"><i class="fa fa-download"></i> Release (86.94 MB)</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-bundle-0.3.2-VC12-x64-Debug-b22.zip" class="button hollow tiny"><i class="fa fa-download"></i> Debug (211.08 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-bundle-{{ site.omefiles.version }}-VC12-x64-Release-b{{ site.omefiles.build }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Release (86.94 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-bundle-{{ site.omefiles.version }}-VC12-x64-Debug-b{{ site.omefiles.build }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Debug (211.08 MB)</a>
                     </div>
                 </div>
             </div>
@@ -80,8 +80,8 @@ title: OME Files Downloads
                     <div class="card-section">
                         <img alt="Windows logo" src="{{ site.baseurl }}/img/logos/3rd-party_windows.png">
                         <h5>Windows VC12 32‑bit (VS2013)</h5>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-bundle-0.3.2-VC12-x86-Release-b22.zip" class="button hollow tiny"><i class="fa fa-download"></i> Release (78.1 MB)</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-bundle-0.3.2-VC12-x86-Debug-b22.zip" class="button hollow tiny"><i class="fa fa-download"></i> Debug (186.18 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-bundle-{{ site.omefiles.version }}-VC12-x86-Release-b{{ site.omefiles.build }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Release (78.1 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-bundle-{{ site.omefiles.version }}-VC12-x86-Debug-b{{ site.omefiles.build }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Debug (186.18 MB)</a>
                     </div>
                 </div>
             </div>
@@ -90,8 +90,8 @@ title: OME Files Downloads
                     <div class="card-section">
                         <img alt="Windows logo" src="{{ site.baseurl }}/img/logos/3rd-party_windows.png">
                         <h5>Windows VC14 64‑bit (VS2015)</h5>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-bundle-0.3.2-VC14-x64-Release-b22.zip" class="button hollow tiny"><i class="fa fa-download"></i> Release (95.41 MB)</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-bundle-0.3.2-VC14-x64-Debug-b22.zip" class="button hollow tiny"><i class="fa fa-download"></i> Debug (206.04 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-bundle-{{ site.omefiles.version }}-VC14-x64-Release-b{{ site.omefiles.build }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Release (95.41 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-bundle-{{ site.omefiles.version }}-VC14-x64-Debug-b{{ site.omefiles.build }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Debug (206.04 MB)</a>
                     </div>
                 </div>
             </div>
@@ -100,8 +100,8 @@ title: OME Files Downloads
                     <div class="card-section">
                         <img alt="Windows logo" src="{{ site.baseurl }}/img/logos/3rd-party_windows.png">
                         <h5>VC14 32‑bit (VS2015)</h5>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-bundle-0.3.2-VC14-x86-Release-b22.zip" class="button hollow tiny"><i class="fa fa-download"></i> Release (86.15 MB)</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-bundle-0.3.2-VC14-x86-Debug-b22.zip" class="button hollow tiny"><i class="fa fa-download"></i> Debug (183.9 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-bundle-{{ site.omefiles.version }}-VC14-x86-Release-b{{ site.omefiles.build }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Release (86.15 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-bundle-{{ site.omefiles.version }}-VC14-x86-Debug-b{{ site.omefiles.build }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Debug (183.9 MB)</a>
                     </div>
                 </div>
             </div>
@@ -117,8 +117,8 @@ title: OME Files Downloads
                     <div class="card-section">
                         <img alt="Ubuntu logo" src="{{ site.baseurl }}/img/logos/3rd-party_ubuntu.png">
                         <h5>Ubuntu 14.04</h5>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-platform-bundle-0.3.2-Release-Ubuntu14.04-x86_64-b22.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Release (8.87 MB)</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/binaries/ome-files-platform-bundle-0.3.2-Debug-Ubuntu14.04-x86_64-b22.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Debug (32.75 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-platform-bundle-{{ site.omefiles.version }}-Release-Ubuntu14.04-x86_64-b{{ site.omefiles.build }}.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Release (8.87 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-platform-bundle-{{ site.omefiles.version }}-Debug-Ubuntu14.04-x86_64-b{{ site.omefiles.build }}.tar.xz" class="button hollow tiny"><i class="fa fa-download"></i> Debug (32.75 MB)</a>
                     </div>
                 </div>
             </div>
@@ -128,7 +128,7 @@ title: OME Files Downloads
                         <img alt="C++ logo" src="{{ site.baseurl }}/img/logos/3rd-party_cpp.png">
                         <h5>OME Common</h5>
                         <a href="http://github.com/ome/ome-common-cpp" class="button hollow tiny"><i class="fa fa-github"></i> View Repo</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-common-cpp/5.4.0/source/ome-common-cpp-5.4.0.zip" class="button hollow tiny"><i class="fa fa-download"></i> Download Zip</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-common-cpp/{{ site.omecommoncpp.version }}/source/ome-common-cpp-{{ site.omecommoncpp.version }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Download Zip</a>
                     </div>
                 </div>
             </div>
@@ -138,7 +138,7 @@ title: OME Files Downloads
                         <img alt="C++ logo" src="{{ site.baseurl }}/img/logos/3rd-party_cpp.png">
                         <h5>OME Model</h5>
                         <a href="http://github.com/ome/ome-model" class="button hollow tiny"><i class="fa fa-github"></i> View Repo</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-model/5.5.1/source/ome-model-5.5.1.zip" class="button hollow tiny"><i class="fa fa-download"></i> Download Zip</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-model/{{ site.omemodel.version }}/source/ome-model-{{ site.omemodel.version }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Download Zip</a>
                     </div>
                 </div>
             </div>
@@ -148,7 +148,7 @@ title: OME Files Downloads
                         <img alt="C++ logo" src="{{ site.baseurl }}/img/logos/3rd-party_cpp.png">
                         <h5>OME Files</h5>
                         <a href="http://github.com/ome/ome-files-cpp" class="button hollow tiny"><i class="fa fa-github"></i> View Repo</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/source/ome-files-cpp-0.3.2.zip" class="button hollow tiny"><i class="fa fa-download"></i> Download Zip</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/source/ome-files-cpp-{{ site.omefiles.version }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Download Zip</a>
                     </div>
                 </div>
             </div>
@@ -158,7 +158,7 @@ title: OME Files Downloads
                         <img alt="C++ logo" src="{{ site.baseurl }}/img/logos/3rd-party_cpp.png">
                         <h5 style="font-size: .99rem;">OME QtWidgets</h5>
                         <a href="http://github.com/ome/ome-qtwidgets" class="button hollow tiny"><i class="fa fa-github"></i> View Repo</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-qtwidgets/5.4.0/source/ome-qtwidgets-5.4.0.zip" class="button hollow tiny"><i class="fa fa-download"></i> Download Zip</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-qtwidgets/{{ site.omeqtwidgets.version }}/source/ome-qtwidgets-{{ site.omeqtwidgets.version }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Download Zip</a>
                     </div>
                 </div>
             </div>
@@ -168,7 +168,7 @@ title: OME Files Downloads
                         <img alt="OME logo" style="max-height: 90px;" src="{{ site.baseurl }}/img/logos/ome-logomark.svg">
                         <h5 style="font-size: .96rem; margin: 10px 0 15px;">OME Super-Build</h5>
                         <a href="http://github.com/ome/ome-cmake-superbuild" class="button hollow tiny"><i class="fa fa-github"></i> View Repo</a>
-                        <a href="http://downloads.openmicroscopy.org/ome-cmake-superbuild/0.3.2/source/ome-cmake-superbuild-0.3.2.zip" class="button hollow tiny"><i class="fa fa-download"></i> Download Zip</a>
+                        <a href="http://downloads.openmicroscopy.org/ome-cmake-superbuild/{{ site.omecmakesuperbuild.version }}/source/ome-cmake-superbuild-{{ site.omecmakesuperbuild.version }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Download Zip</a>
                     </div>
                 </div>
             </div>
@@ -184,8 +184,8 @@ title: OME Files Downloads
             <div class="row">
                 <div class="small-12 columns bg-image-text-container-cta text-center">
                     <p class="hero-subheader">All components available for this version of OME Files are available here:</p>
-                    <a href="https://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/sources" class="large btn-blue button sites-button hide-for-small-only" style="margin-right: 10px; text-shadow: none;">Download Sources</a>
-                    <a href="https://downloads.openmicroscopy.org/ome-files-cpp/0.3.2/22/tools" class="large btn-blue button sites-button hide-for-small-only" style="text-shadow: none;">Download Tools</a>
+                    <a href="https://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/sources" class="large btn-blue button sites-button hide-for-small-only" style="margin-right: 10px; text-shadow: none;">Download Sources</a>
+                    <a href="https://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/tools" class="large btn-blue button sites-button hide-for-small-only" style="text-shadow: none;">Download Tools</a>
                 </div>
             </div>
         </header>

--- a/products/ome-files/downloads/index.html
+++ b/products/ome-files/downloads/index.html
@@ -99,7 +99,7 @@ title: OME Files Downloads
                 <div class="card card-download-small">
                     <div class="card-section">
                         <img alt="Windows logo" src="{{ site.baseurl }}/img/logos/3rd-party_windows.png">
-                        <h5>VC14 32‑bit (VS2015)</h5>
+                        <h5>Windows VC14 32‑bit (VS2015)</h5>
                         <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-bundle-{{ site.omefiles.version }}-VC14-x86-Release-b{{ site.omefiles.build }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Release (86.15 MB)</a>
                         <a href="http://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/binaries/ome-files-bundle-{{ site.omefiles.version }}-VC14-x86-Debug-b{{ site.omefiles.build }}.zip" class="button hollow tiny"><i class="fa fa-download"></i> Debug (183.9 MB)</a>
                     </div>

--- a/products/ome-files/index.html
+++ b/products/ome-files/index.html
@@ -8,7 +8,7 @@ title: OME Files
                     <h1 class="hero-main-header"><img src="{{ site.baseurl }}/img/logos/ome-files-white.svg" alt="OME Files logo" class="logo-hero" /></h1>
                     <p class="hero-subheader small-12">The solution for developers to support the OME data model and OME-TIFF in their software</p>
                     <br>
-                    <a href="{{ site.baseurl }}/products/ome-files/downloads/" class="large button sites-button hide-for-small-only btn-blue">Download Version 0.3.2</a>
+                    <a href="{{ site.baseurl }}/products/ome-files/downloads/" class="large button sites-button hide-for-small-only btn-blue">Download Version {{ site.omefiles.version }}</a>
                 </div>
             </div>
         </header>

--- a/products/omero/downloads/index.html
+++ b/products/omero/downloads/index.html
@@ -4,7 +4,7 @@ title: OMERO Downloads
 ---     
         <div class="callout large primary" id="bg-image-omero">
             <div class="row column text-center">
-                <h1>OMERO 5.3.2 Downloads</h1>
+                <h1>OMERO {{ site.omero.version }} Downloads</h1>
                 <a href="{{ site.baseurl }}/2017/05/16/omero-5-3-2.html" class="large btn-red button sites-button hide-for-small-only" style="text-shadow: none;">Read the Release Announcement</a>
             </div>
         </div>
@@ -21,9 +21,9 @@ title: OMERO Downloads
                     <div class="card-section">
                         <img alt="Windows logo" src="{{ site.baseurl }}/img/logos/3rd-party_windows.png">
                         <h5>Windows</h5>
-                        <h6>OMERO.insight-5.3.2-ice36-b62-win.zip</h6>
+                        <h6>OMERO.insight-{{ site.omero.version }}-ice36-{{ site.omero.build }}-win.zip</h6>
                         <p></p>
-                        <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.insight-5.3.2-ice36-b62-win.zip" class="button hollow small"><i class="fa fa-download"></i> Download (78.39 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.insight-{{ site.omero.version }}-ice36-{{ site.omero.build }}-win.zip" class="button hollow small"><i class="fa fa-download"></i> Download (78.39 MB)</a>
                     </div>
                 </div>
             </div>
@@ -32,9 +32,9 @@ title: OMERO Downloads
                     <div class="card-section">
                         <img alt="MacOS X logo" src="{{ site.baseurl }}/img/logos/3rd-party_macosx.jpg">
                         <h5>Mac OS X</h5>
-                        <h6>OMERO.insight-5.3.2-ice36-b62-mac.zip</h6>
+                        <h6>OMERO.insight-{{ site.omero.version }}-ice36-{{ site.omero.build }}-mac.zip</h6>
                         <p></p>
-                        <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.insight-5.3.2-ice36-b62-mac.zip" class="button hollow small"><i class="fa fa-download"></i> Download (78.17 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.insight-{{ site.omero.version }}-ice36-{{ site.omero.build }}-mac.zip" class="button hollow small"><i class="fa fa-download"></i> Download (78.17 MB)</a>
                     </div>
                 </div>
             </div>
@@ -43,9 +43,9 @@ title: OMERO Downloads
                     <div class="card-section">
                         <img alt="Linux logo" src="{{ site.baseurl }}/img/logos/3rd-party_linux.png">
                         <h5>Linux</h5>
-                        <h6>OMERO.insight-5.3.2-ice36-b62-linux.zip</h6>
+                        <h6>OMERO.insight-{{ site.omero.version }}-ice36-{{ site.omero.build }}-linux.zip</h6>
                         <p></p>
-                        <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.insight-5.3.2-ice36-b62-linux.zip" class="button hollow small"><i class="fa fa-download"></i> Download (78.04 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.insight-{{ site.omero.version }}-ice36-{{ site.omero.build }}-linux.zip" class="button hollow small"><i class="fa fa-download"></i> Download (78.04 MB)</a>
                     </div>
                 </div>
             </div>
@@ -61,9 +61,9 @@ title: OMERO Downloads
                     <div class="card-section">
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_fiji.png">
                         <h5>Image J / Fiji</h5>
-                        <h6>OMERO.insight-ij-5.3.2-ice36-b62.zip</h6>
+                        <h6>OMERO.insight-ij-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip</h6>
                         <p class="card-caption">View instructions at <a href="http://help.openmicroscopy.org/imagej.html" target="_blank">Using ImageJ with OMERO</a>.</p>
-                        <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.insight-ij-5.3.2-ice36-b62.zip" class="button hollow small"><i class="fa fa-download"></i> Download (70.23 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.insight-ij-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (70.23 MB)</a>
                     </div>
                 </div>
             </div>
@@ -72,9 +72,9 @@ title: OMERO Downloads
                     <div class="card-section">
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_matlab.png">
                         <h5>Matlab</h5>
-                        <h6>OMERO.matlab-5.3.2-ice36-b62.zip</h6>
+                        <h6>OMERO.matlab-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip</h6>
                         <p class="card-caption">View instructions at <a href="http://www.openmicroscopy.org/site/support/omero/developers/Matlab.html" target="_blank">OMERO Matlab language bindings</a>.</p>
-                        <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.matlab-5.3.2-ice36-b62.zip" class="button hollow small"><i class="fa fa-download"></i> Download (22.49 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.matlab-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (22.49 MB)</a>
                     </div>
                 </div>
             </div>
@@ -83,9 +83,9 @@ title: OMERO Downloads
                     <div class="card-section">
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_server.svg">
                         <h5>Server (Ice 3.6)</h5>
-                        <h6>OMERO.server-5.3.2-ice36-b62.zip</h6>
+                        <h6>OMERO.server-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip</h6>
                         <p></p>
-                        <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.server-5.3.2-ice36-b62.zip" class="button hollow small"><i class="fa fa-download"></i> Download (155.8 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.server-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (155.8 MB)</a>
                     </div>
                 </div>
             </div>
@@ -98,9 +98,9 @@ title: OMERO Downloads
                     <div class="card-section">
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_public-api.svg">
                         <h5>API Documentation</h5>
-                        <h6>OMERO.apidoc-5.3.2-ice36-b62.zip</h6>
-                        <p class="card-caption">The OMERO API documentation is also available to read on the web <a href="http://downloads.openmicroscopy.org/omero/5.3.2/api/">here</a>.</p>
-                        <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.apidoc-5.3.2-ice36-b62.zip" class="button hollow small"><i class="fa fa-download"></i> Download (34.48 MB)</a>
+                        <h6>OMERO.apidoc-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip</h6>
+                        <p class="card-caption">The OMERO API documentation is also available to read on the web <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/api/">here</a>.</p>
+                        <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.apidoc-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (34.48 MB)</a>
                     </div>
                 </div>
             </div>
@@ -110,9 +110,9 @@ title: OMERO Downloads
                     <div class="card-section">
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_python.svg">
                         <h5>Python (Ice 3.6)</h5>
-                        <h6>OMERO.py-5.3.2-ice36-b62.zip</h6>
+                        <h6>OMERO.py-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip</h6>
                         <p class="card-caption">OMERO.py can be used to install OMERO.web decoupled from the OMERO.server, see the <a href="http://www.openmicroscopy.org/site/support/omero/sysadmins/unix/install-web.html">OMERO.web documentation</a> for details.</p>
-                        <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.py-5.3.2-ice36-b62.zip" class="button hollow small"><i class="fa fa-download"></i> Download (9.09 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.py-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (9.09 MB)</a>
                     </div>
                 </div>
             </div>
@@ -122,9 +122,9 @@ title: OMERO Downloads
                     <div class="card-section">
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_java.png">
                         <h5>Java (Ice 3.6)</h5>
-                        <h6>OMERO.java-5.3.2-ice36-b62.zip</h6>
-                        <p class="card-caption">The OMERO Java API documentation is available to read on the web <a href="http://downloads.openmicroscopy.org/omero/5.3.2/api/">here</a>.</p>
-                        <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/OMERO.java-5.3.2-ice36-b62.zip" class="button hollow small"><i class="fa fa-download"></i> Download (80.81 MB)</a>
+                        <h6>OMERO.java-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip</h6>
+                        <p class="card-caption">The OMERO Java API documentation is available to read on the web <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/api/">here</a>.</p>
+                        <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.java-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (80.81 MB)</a>
                     </div>
                 </div>
             </div>
@@ -134,11 +134,11 @@ title: OMERO Downloads
                     <div class="card-section">
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_scripts.svg">
                         <h5>Source Code</h5>
-                        <h6>openmicroscopy-5.3.2.zip</h6>
+                        <h6>openmicroscopy-{{ site.omero.version }}.zip</h6>
                         <p class="card-caption">View instructions at <a href="http://www.openmicroscopy.org/site/support/omero/developers/installation.html" target="_blank">Installing OMERO from source</a>.</p>
-                        <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/openmicroscopy-5.3.2.zip" class="button hollow small"><i class="fa fa-download"></i> Download (43.03 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/openmicroscopy-{{ site.omero.version }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (43.03 MB)</a>
                         <a href="http://github.com/openmicroscopy/openmicroscopy" target="_blank" class="button hollow small"><i class="fa fa-github"></i> View GitHub Repository</a>
-                        <a href="https://github.com/openmicroscopy/openmicroscopy/tree/v5.3.2" target="_blank" class="button hollow small"><i class="fa fa-github"></i> View Git Tag</a>
+                        <a href="https://github.com/openmicroscopy/openmicroscopy/tree/v{{ site.omero.version }}" target="_blank" class="button hollow small"><i class="fa fa-github"></i> View Git Tag</a>
                     </div>
                 </div>
             </div>

--- a/products/omero/index.html
+++ b/products/omero/index.html
@@ -9,7 +9,7 @@ usergroup: omero
                     <h1 class="hero-main-header"><img src="{{ site.baseurl }}/img/logos/omero-white.svg" alt="OMERO logo" class="logo-hero" /></h1>
                     <p class="hero-subheader small-12">From the microscope to publication, OMERO handles all your images in a secure central repository. You can view, organize, analyze and share your data from anywhere you have internet access. Work with your images from a desktop app (Windows, Mac or Linux), from the web or from 3rd party software. Over 140 image file formats supported, including all major microscope formats.</p>
                     <br>
-                    <a href="{{ site.baseurl }}/products/omero/downloads/" class="large button sites-button hide-for-small-only btn-red">Download Version 5.3.2</a>
+                    <a href="{{ site.baseurl }}/products/omero/downloads/" class="large button sites-button hide-for-small-only btn-red">Download Version {{ site.omero.version }}</a>
                 </div>
             </div>
         </header>


### PR DESCRIPTION
This PR proposes to migrate the management of the product versions to the top-level `_config.yml` to ease the maintenance, updates and prevent out-of-sync issues.

The first commit leaves the artifact file sizes hardcoded in the product downloads pages for now. Happy to hear thoughts on how to deal with those. They could also be migrated to the top-level configuration file as well if we want to manage everything  that way.