### PR TITLE
OMERO Downloads: unhides CTA for mobile layout

### DIFF
--- a/products/omero/downloads/index.html
+++ b/products/omero/downloads/index.html
@@ -5,7 +5,7 @@ title: OMERO Downloads
         <div class="callout large primary" id="bg-image-omero">
             <div class="row column text-center">
                 <h1>OMERO {{ site.omero.version }} Downloads</h1>
-                <a href="{{ site.baseurl }}/2017/05/16/omero-5-3-2.html" class="large btn-red button sites-button hide-for-small-only" style="text-shadow: none;">Read the Release Announcement</a>
+                <a href="{{ site.baseurl }}/2017/05/16/omero-5-3-2.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
             </div>
         </div>
         


### PR DESCRIPTION
Small fix for mobile that un-hides a button on the OMERO Downloads page. 