### PR TITLE
News pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ ruby RUBY_VERSION
 # Happy Jekylling!
 gem "jekyll", "3.4.3"
 
+gem "jekyll-paginate"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ markdown: kramdown
 baseurl: /www.openmicroscopy.org
 
 gems: [jekyll-paginate]
-paginate: 5
+paginate: 10
 paginate_path: "/community/news/page:num/"
 
 bf:

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,10 @@ markdown: kramdown
 
 baseurl: /www.openmicroscopy.org
 
+gems: [jekyll-paginate]
+paginate: 5
+paginate_path: "/community/news/page:num/"
+
 bf:
  version: 5.5.2
 

--- a/community/news/index.html
+++ b/community/news/index.html
@@ -19,7 +19,7 @@ main-blurb: New releases and other announcements
           {% for page in (1..paginator.total_pages) %}
           <li>
             {% if page == paginator.page %}
-              <em>{{ page }}</em>
+              {{ page }}
             {% elsif page == 1 %}
               <a href="{{ '/community/news' | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
             {% else %}

--- a/community/news/index.html
+++ b/community/news/index.html
@@ -7,6 +7,7 @@ main-blurb: New releases and other announcements
         <hr class="whitespace">
         <div id="community-posts" class="row">
 {% if paginator.total_pages > 1 %}
+        <div class="small-12 medium-8 medium-offset-2 columns">
         <ul class="pagination">
           <li>
           {% if paginator.previous_page %}
@@ -34,6 +35,7 @@ main-blurb: New releases and other announcements
           {% endif %}
           </li>
         </ul>
+    </div>
 {% endif %}
 {% for post in paginator.posts %}
             <div class="small-12 medium-8 medium-offset-2 columns"></h6>

--- a/community/news/index.html
+++ b/community/news/index.html
@@ -38,8 +38,8 @@ main-blurb: New releases and other announcements
     </div>
 {% endif %}
 {% for post in paginator.posts %}
-            <div class="small-12 medium-8 medium-offset-2 columns"></h6>
-                <h6><i class="fa fa-calendar"></i> {{post.date | date: "%B %d, %Y"}}
+            <div class="small-12 medium-8 medium-offset-2 columns">
+                <h6><i class="fa fa-calendar"></i> {{post.date | date: "%B %d, %Y"}}</h6>
                 <h2><a href="{{ post.url | relative_url }}">{{post.title}}</a></h2>
                 <p class="card-caption">{{post.intro-blurb}}</p>
                 <div class="row"></div>

--- a/community/news/index.html
+++ b/community/news/index.html
@@ -6,6 +6,15 @@ main-blurb: New releases and other announcements
         <!-- begin News -->
         <hr class="whitespace">
         <div id="community-posts" class="row">
+{% for post in paginator.posts %}
+            <div class="small-12 medium-8 medium-offset-2 columns">
+                <h6><i class="fa fa-calendar"></i> {{post.date | date: "%B %d, %Y"}}</h6>
+                <h2><a href="{{ post.url | relative_url }}">{{post.title}}</a></h2>
+                <p class="card-caption">{{post.intro-blurb}}</p>
+                <div class="row"></div>
+            </div>
+            <hr class="medium-8">
+{% endfor %}
 {% if paginator.total_pages > 1 %}
         <div class="small-12 medium-8 medium-offset-2 columns">
         <ul class="pagination">
@@ -37,15 +46,6 @@ main-blurb: New releases and other announcements
         </ul>
     </div>
 {% endif %}
-{% for post in paginator.posts %}
-            <div class="small-12 medium-8 medium-offset-2 columns">
-                <h6><i class="fa fa-calendar"></i> {{post.date | date: "%B %d, %Y"}}</h6>
-                <h2><a href="{{ post.url | relative_url }}">{{post.title}}</a></h2>
-                <p class="card-caption">{{post.intro-blurb}}</p>
-                <div class="row"></div>
-            </div>
-            <hr class="medium-8">
-{% endfor %}
         </div>
         <!-- end News -->
         <hr class="whitespace">

--- a/community/news/index.html
+++ b/community/news/index.html
@@ -2,12 +2,40 @@
 layout: community
 title: News
 main-blurb: New releases and other announcements
----          
-                
+---                      
         <!-- begin News -->
         <hr class="whitespace">
         <div id="community-posts" class="row">
-{% for post in site.posts %}
+{% if paginator.total_pages > 1 %}
+        <ul class="pagination">
+          <li>
+          {% if paginator.previous_page %}
+            <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&laquo; Prev</a>
+          {% else %}
+            <span>&laquo; Prev</span>
+          {% endif %}
+          </li>
+          {% for page in (1..paginator.total_pages) %}
+          <li>
+            {% if page == paginator.page %}
+              <em>{{ page }}</em>
+            {% elsif page == 1 %}
+              <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+            {% else %}
+              <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
+            {% endif %}
+          </li>
+          {% endfor %}
+          <li>
+          {% if paginator.next_page %}
+            <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Next &raquo;</a>
+          {% else %}
+            <span>Next &raquo;</span>
+          {% endif %}
+          </li>
+        </ul>
+{% endif %}
+{% for post in paginator.posts %}
             <div class="small-12 medium-8 medium-offset-2 columns"></h6>
                 <h6><i class="fa fa-calendar"></i> {{post.date | date: "%B %d, %Y"}}
                 <h2><a href="{{ post.url | relative_url }}">{{post.title}}</a></h2>

--- a/community/news/index.html
+++ b/community/news/index.html
@@ -21,7 +21,7 @@ main-blurb: New releases and other announcements
             {% if page == paginator.page %}
               <em>{{ page }}</em>
             {% elsif page == 1 %}
-              <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+              <a href="{{ '/community/news' | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
             {% else %}
               <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
             {% endif %}

--- a/css/openmicroscopy.css
+++ b/css/openmicroscopy.css
@@ -609,6 +609,14 @@ ul.event-workshop {
         text-transform: uppercase;
     }
 
+ul.pagination li a {
+    color: #455a64; }
+    ul.pagination li a:hover {
+        background-color: #eceff1; }
+    ul.pagination li.disabled {
+        color: #b0bec5;
+    }
+
 /* ========== footer ==========*/
 #footer {
     background-color: #eceff1;
@@ -633,4 +641,4 @@ ul.event-workshop {
     margin-bottom: 30px;
     max-height: 30px;
     color: #ffffff;
-}c
+}


### PR DESCRIPTION
See https://trello.com/c/o0zue7WC/23-add-pagination-to-news

Enables Jekyll pagination (see https://jekyllrb.com/docs/pagination/) using the pagination style produced by @lunson.

To test this PR go to https://snoopycrimecop.github.io/www.openmicroscopy.org/community/news/ and check the news are now paginated. The number of posts per page is initially set to 5 but can be increased.