### PR TITLE
News migration

### DIFF
--- a/_posts/2015-05-28-omero-bio-formats-5-1-2.md
+++ b/_posts/2015-05-28-omero-bio-formats-5-1-2.md
@@ -1,0 +1,66 @@
+---
+layout: post
+title: Release of OMERO & Bio-Formats 5.1.2
+intro-blurb: The OME Consortium are pleased to announce the release of OMERO & Bio-Formats 5.1.2
+---
+Today we are releasing OMERO and Bio-Formats 5.1.2. This is a point release that contains bug-fixes, but also adds several new features to Bio-Formats and OMERO.
+
+**Bio-Formats**
+
+Bio-Formats 5.1.2 adds writing support for OME-TIFF to the native C++ implementation, allows export of OME BigTIFF, and adds a Slidebook6 reader (many thanks to Richard Myers of 3i - Intelligent Imaging Innovations (https://www.intelligent-imaging.com)
+
+Other improvements include:
+
+* improved MATLAB developer documentation 
+* preliminary work to make MATLAB toolbox work with Octave
+* ImageJ fixes for getPlanePosition* macro extension methods and display of composite color virtual stacks
+* many bug fixes for formats including:
+    * Nikon ND2 - improved parsing of plane position and timestamp data
+    * TIFF - reduced memory required to read color lookup tables
+    * Zeiss LSM - improved parsing of 16-bit color lookup tables
+    * Zeiss CZI - fixed ordering of original metadata table and reading of large pre-stitched tiled images
+    * AIM - fixed handling of truncated files
+    * Metamorph/MetaXpress TIFF - improved UIC1 metadata tag parsing
+    * Leica LIF - improved metadata handling
+
+Full details can be found at [http://www.openmicroscopy.org/site/support/bio-formats5.1/about/whats-new.html]
+
+The software is available at:
+http://downloads.openmicroscopy.org/bio-formats/5.1.2
+and the C++ implementation is available from:
+http://downloads.openmicroscopy.org/bio-formats-cpp/5.1.2/
+
+**OMERO**
+
+OMERO 5.1.2 features a number of bug fixes and also introduces some new functionality. 
+
+Improvements include:
+
+* Read-Write group support
+* LDAP plugin can now set group owners
+* auto log-in via webstart for users already logged into OMERO.web 
+* ability to attach results tables from ImageJ/Fiji to your images in OMERO
+* better delete functionality and warnings in the UI
+* magnification values now displayed as multiplication factors (e.g. 40x) rather than percentages
+* long file names more readable in OMERO.insight data tree
+* various deployment fixes
+* OMERO.web updates include:
+    * image interpolation on zoom
+    * optimization of plate grid and right-hand panel
+    * download single original files
+    * faster loading of large datasets
+
+Critical bug fixes include:
+
+* in-place import file handle leak
+* various unicode and unit failures (thanks to Tristan Nowak for his help in identifying several of these bugs)
+ 
+Full details are available at [http://www.openmicroscopy.org/site/support/omero5.1/users/history.html]
+
+The software is available at:
+[archived downloads](http://downloads.openmicroscopy.org/omero/5.1.2)
+
+Upgrade information is at [http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/server-upgrade.html].
+
+
+For any problems or comments, please use the [OME Forums or mailing lists]({{ site.baseurl }}/support/)

--- a/_posts/2015-05-28-omero-bio-formats-5-1-2.md
+++ b/_posts/2015-05-28-omero-bio-formats-5-1-2.md
@@ -1,13 +1,13 @@
 ---
 layout: post
 title: Release of OMERO & Bio-Formats 5.1.2
-intro-blurb: The OME Consortium are pleased to announce the release of OMERO & Bio-Formats 5.1.2
+intro-blurb: The OME Consortium is pleased to announce the release of OMERO & Bio-Formats 5.1.2
 ---
 Today we are releasing OMERO and Bio-Formats 5.1.2. This is a point release that contains bug-fixes, but also adds several new features to Bio-Formats and OMERO.
 
 **Bio-Formats**
 
-Bio-Formats 5.1.2 adds writing support for OME-TIFF to the native C++ implementation, allows export of OME BigTIFF, and adds a Slidebook6 reader (many thanks to Richard Myers of 3i - Intelligent Imaging Innovations (https://www.intelligent-imaging.com)
+Bio-Formats 5.1.2 adds writing support for OME-TIFF to the native C++ implementation, allows export of OME BigTIFF, and adds a Slidebook6 reader (many thanks to Richard Myers of 3i - Intelligent Imaging Innovations [https://www.intelligent-imaging.com](https://www.intelligent-imaging.com)
 
 Other improvements include:
 
@@ -23,12 +23,12 @@ Other improvements include:
     * Metamorph/MetaXpress TIFF - improved UIC1 metadata tag parsing
     * Leica LIF - improved metadata handling
 
-Full details can be found at [http://www.openmicroscopy.org/site/support/bio-formats5.1/about/whats-new.html]
+Full details can be found at [Bio-Formats version history](http://www.openmicroscopy.org/site/support/bio-formats5.1/about/whats-new.html])
 
 The software is available at:
-http://downloads.openmicroscopy.org/bio-formats/5.1.2
+[archived downloads](http://downloads.openmicroscopy.org/bio-formats/5.1.2)
 and the C++ implementation is available from:
-http://downloads.openmicroscopy.org/bio-formats-cpp/5.1.2/
+[archived downloads](http://downloads.openmicroscopy.org/bio-formats-cpp/5.1.2/)
 
 **OMERO**
 
@@ -55,12 +55,12 @@ Critical bug fixes include:
 * in-place import file handle leak
 * various unicode and unit failures (thanks to Tristan Nowak for his help in identifying several of these bugs)
  
-Full details are available at [http://www.openmicroscopy.org/site/support/omero5.1/users/history.html]
+Full details are available at [http://www.openmicroscopy.org/site/support/omero5.1/users/history.html](http://www.openmicroscopy.org/site/support/omero5.1/users/history.html)
 
 The software is available at:
 [archived downloads](http://downloads.openmicroscopy.org/omero/5.1.2)
 
-Upgrade information is at [http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/server-upgrade.html].
+Upgrade information is at [http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/server-upgrade.html](http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/server-upgrade.html).
 
 
 For any problems or comments, please use the [OME Forums or mailing lists]({{ site.baseurl }}/support/)

--- a/_posts/2015-07-20-bio-formats-5-1-3.md
+++ b/_posts/2015-07-20-bio-formats-5-1-3.md
@@ -1,0 +1,50 @@
+---
+layout: post
+title: Release of Bio-Formats 5.1.3
+intro-blurb: The OME Consortium are pleased to announce the release of Bio-Formats 5.1.3
+---
+Today we are releasing Bio-Formats 5.1.3. This is a point release that contains bug-fixes, but also adds several new features to Bio-Formats.
+
+Bio-Formats 5.1.3 improvements include:
+
+* Native C++ updates:
+    * Added cmake superbuild to build core dependencies (zlib, bzip2, png, icu, xerces, boost)
+    * Progress on support for Windows
+* Bug fixes, including:
+    * Fixed segfault in the showinf tool used with the C++ bindings
+    * Allow reading from https URLs
+    * ImageJ - improved performance of displaying ROIs
+    * Command line tools - fixed bfconvert to correctly create datasets with multiple files
+* File format fixes, including:
+    * Metamorph
+        - improved detection of time series
+        - fixed .nd datasets with variable Z and T counts in each channel
+        - fixed .nd datasets that contain invalid TIFF/STK files
+        - fixed dimensions when the number of planes does not match the recorded Z, C, and T sizes
+    * SlideBook - improved native library detection (thanks to Richard Myers)
+    * JPEG - fixed decompression of lossless files with multiple channels (thanks to Aaron Avery)
+    * Imspector OBF - updated to support version 2 files (thanks to Bjoern Thiel)
+    * Imspector MSR - improved detection of Z stacks
+    * PerkinElmer Opera Flex - improved handling of multiple acquisitions of the same plate
+    * Zeiss CZI - fixed error when opening single-file datasets whose names contained "(" and ")"
+    * TIFF - improved speed of reading files with many tiles
+    * AVI - updated to read frame index (idx1) tables
+    * Nikon ND2 - fixed channel counts for files with more than 3 channels
+    * PNG - fixed decoding of interlaced images with a width or height that is not a multiple of 8
+    * PSD - improved reading of compressed images
+* Documentation improvements, including:
+    * updated instructions for writing a new file format reader
+    * updated usage information for command line tools
+    * new Javadocs for the MetadataStore and MetadataRetrieve interfaces
+
+
+Full details can be found at [http://www.openmicroscopy.org/site/support/bio-formats5/about/whats-new.html]
+
+The software is available at:
+[archived downloads](http://downloads.openmicroscopy.org/bio-formats/5.1.3)
+
+and the C++ implementation is available from:
+
+[archived downloads](http://downloads.openmicroscopy.org/bio-formats-cpp/5.1.3/)
+
+For any problems or comments, please use the [OME Forums or mailing lists]({{ site.baseurl }}/support/)

--- a/_posts/2015-07-20-bio-formats-5-1-3.md
+++ b/_posts/2015-07-20-bio-formats-5-1-3.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Release of Bio-Formats 5.1.3
-intro-blurb: The OME Consortium are pleased to announce the release of Bio-Formats 5.1.3
+intro-blurb: The OME team is pleased to announce the release of Bio-Formats 5.1.3
 ---
 Today we are releasing Bio-Formats 5.1.3. This is a point release that contains bug-fixes, but also adds several new features to Bio-Formats.
 
@@ -17,10 +17,10 @@ Bio-Formats 5.1.3 improvements include:
     * Command line tools - fixed bfconvert to correctly create datasets with multiple files
 * File format fixes, including:
     * Metamorph
-        - improved detection of time series
-        - fixed .nd datasets with variable Z and T counts in each channel
-        - fixed .nd datasets that contain invalid TIFF/STK files
-        - fixed dimensions when the number of planes does not match the recorded Z, C, and T sizes
+        * improved detection of time series
+        * fixed .nd datasets with variable Z and T counts in each channel
+        * fixed .nd datasets that contain invalid TIFF/STK files
+        * fixed dimensions when the number of planes does not match the recorded Z, C, and T sizes
     * SlideBook - improved native library detection (thanks to Richard Myers)
     * JPEG - fixed decompression of lossless files with multiple channels (thanks to Aaron Avery)
     * Imspector OBF - updated to support version 2 files (thanks to Bjoern Thiel)
@@ -38,7 +38,7 @@ Bio-Formats 5.1.3 improvements include:
     * new Javadocs for the MetadataStore and MetadataRetrieve interfaces
 
 
-Full details can be found at [http://www.openmicroscopy.org/site/support/bio-formats5/about/whats-new.html]
+Full details can be found at [Bio-Formats version history](http://www.openmicroscopy.org/site/support/bio-formats5/about/whats-new.html)
 
 The software is available at:
 [archived downloads](http://downloads.openmicroscopy.org/bio-formats/5.1.3)

--- a/_posts/2015-07-22-latest-java-security-issue.md
+++ b/_posts/2015-07-22-latest-java-security-issue.md
@@ -5,6 +5,6 @@ intro-blurb: A recent security vulnerability on Java prompted Oracle to release 
 ---
 This upgrade prevented OMERO clients from connecting to the server. A fix for this issue is now available, you should upgrade your Java version to take advantage of the security fix and refer your system administrator to 
 
-http://blog.openmicroscopy.org/tech-issues/2015/07/21/java-issue/ 
+[http://blog.openmicroscopy.org/tech-issues/2015/07/21/java-issue/](http://blog.openmicroscopy.org/tech-issues/2015/07/21/java-issue/)
 
 for details of how to patch your server. You do not need to download new clients and this fix will also be included in the next release of OMERO (5.1.3).

--- a/_posts/2015-07-22-latest-java-security-issue.md
+++ b/_posts/2015-07-22-latest-java-security-issue.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title: Latest Java security issue
+intro-blurb: A recent security vulnerability on Java prompted Oracle to release critical patches for the JDK in versions 6u101, 7u85 and 8u51.
+---
+This upgrade prevented OMERO clients from connecting to the server. A fix for this issue is now available, you should upgrade your Java version to take advantage of the security fix and refer your system administrator to 
+
+http://blog.openmicroscopy.org/tech-issues/2015/07/21/java-issue/ 
+
+for details of how to patch your server. You do not need to download new clients and this fix will also be included in the next release of OMERO (5.1.3).


### PR DESCRIPTION
Takes care of the migration of the following links,
https://www.openmicroscopy.org/site/news/latest-java-security-issue
https://www.openmicroscopy.org/site/news/release-of-bio-formats-5.1.3
https://www.openmicroscopy.org/site/news/release-of-omero-bio-formats-5.1.2

Have done all the files that were listed in my checklist except for the following one, 
https://www.openmicroscopy.org/site/news/release-of-omero-5.1.3
This is duplicated in the checklist and has already been done by @mtbc 

@sbesson @hflynn 