### PR TITLE
Artifacts sizes generation

### DIFF
--- a/bio-formats/downloads/index.html
+++ b/bio-formats/downloads/index.html
@@ -21,7 +21,7 @@ title: Bio-Formats Downloads
                         <h5>Bio-Formats Package</h5>
                         <h6>bioformats_package.jar</h6>
                         <p class="card-caption">The complete bundle for end users containing everything needed to read images into ImageJ. Instructions for installing Bio-Formats in ImageJ are available in the <a href="https://docs.openmicroscopy.org/bio-formats/{{ site.bf.version }}/users/imagej/installing.html" taget="_blank">user guide</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats_package.jar" class="button hollow small"><i class="fa fa-download"></i> Download (31.64 MB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats_package.jar" class="button hollow small"><i class="fa fa-download"></i> Download (31.71 MB)</a>
                     </div>
                 </div>
             </div>
@@ -32,7 +32,7 @@ title: Bio-Formats Downloads
                         <h5>Command Line Tools</h5>
                         <h6>bftools.zip</h6>
                         <p class="card-caption">A bundle of scripts for using Bio-Formats on the command line with bioformats_package.jar already included. For more info, see the <a href="https://docs.openmicroscopy.org/bio-formats/{{ site.bf.version }}/users/comlinetools/index.html" target="_blank">command line tools documentation</a>.</p>
-                        <a href="http://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bftools.zip" class="button hollow small"><i class="fa fa-download"></i> Download (29.96 MB)</a>
+                        <a href="http://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bftools.zip" class="button hollow small"><i class="fa fa-download"></i> Download (30.03 MB)</a>
                     </div>
                 </div>
             </div>
@@ -43,7 +43,7 @@ title: Bio-Formats Downloads
                         <h5>MATLAB Toolbox</h5>
                         <h6>bfmatlab.zip</h6>
                         <p class="card-caption">A bundle of functions for using Bio-Formats from MATLAB with bioformats_package.jar already included. For more info, see the <a href="https://docs.openmicroscopy.org/bio-formats/{{ site.bf.version }}/users/matlab/index.html" target="_blank">MATLAB documentation</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bfmatlab.zip" class="button hollow small"><i class="fa fa-download"></i> Download (29.97 MB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bfmatlab.zip" class="button hollow small"><i class="fa fa-download"></i> Download (30.04 MB)</a>
                     </div>
                 </div>
             </div>
@@ -72,7 +72,7 @@ title: Bio-Formats Downloads
                         <h5>API Documentation</h5>
                         <h6>bio-formats-javadocs-{{ site.bf.version }}.zip</h6>
                         <p class="card-caption">The Javadoc bundle containing the Bio-Formats API documentation is <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/api">here</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bio-formats-javadocs-{{ site.bf.version }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (14.7 MB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bio-formats-javadocs-{{ site.bf.version }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (4.82 MB)</a>
                     </div>
                 </div>
             </div>
@@ -83,7 +83,7 @@ title: Bio-Formats Downloads
                         <h5>Source Code</h5>
                         <h6>bioformats-{{ site.bf.version }}.tar.xz</h6>
                         <p></p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-{{ site.bf.version }}.tar.xz" class="button hollow small"><i class="fa fa-download"></i> Download (9.14 MB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-{{ site.bf.version }}.tar.xz" class="button hollow small"><i class="fa fa-download"></i> Download (8.62 MB)</a>
                         <a href="https://github.com/openmicroscopy/bioformats" target="_blank" class="button hollow small"><i class="fa fa-github"></i> View GitHub Repository</a>
                     </div>
                 </div>
@@ -95,7 +95,7 @@ title: Bio-Formats Downloads
                         <h5>Source Code</h5>
                         <h6>bioformats-{{ site.bf.version }}.zip</h6>
                         <p></p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-{{ site.bf.version }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (12.67 MB)</a><br>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-{{ site.bf.version }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (11.19 MB)</a><br>
                         <a href="https://github.com/openmicroscopy/bioformats/tree/v{{ site.bf.version }}" target="_blank" class="button hollow small"><i class="fa fa-github"></i> View Git Tag</a>
                     </div>
                 </div>

--- a/gen_sizes.py
+++ b/gen_sizes.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env venv/bin/python
+# -*- coding: utf-8 -*-
+
+
+import urllib2
+import sys
+
+DOWNLOADS_URL = "https://downloads.openmicroscopy.org/"
+SUFFIXES = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+
+
+def get_bytes_length(name, version, artifact):
+    url = "%s%s/%s/artifacts/%s" % (DOWNLOADS_URL, name, version, artifact)
+    response = urllib2.urlopen(url)
+    meta = response.info()
+    return int(meta.getheaders("Content-Length")[0])
+
+
+def humansize(nbytes):
+    if nbytes == 0:
+        return '0 B'
+    i = 0
+    while nbytes >= 1000 and i < len(SUFFIXES)-1:
+        nbytes /= 1000.
+        i += 1
+    f = ('%.2f' % nbytes).rstrip('0').rstrip('.')
+    return '%s %s' % (f, SUFFIXES[i])
+
+
+def list_artifacts(name, version):
+    url = "%s%s/%s/artifacts/SHA1SUMS" % (DOWNLOADS_URL, name, version)
+    response = urllib2.urlopen(url)
+    shasums = response.read()
+    artifacts = []
+    for i in shasums.split('\n'):
+        lastitem = i.rsplit(' ')[-1]
+        if lastitem:
+            artifacts.append(lastitem)
+    return artifacts
+
+
+def usage():
+    print "gen_sizes.py name version"
+    sys.exit(1)
+
+
+try:
+    name = sys.argv[1]
+    version = sys.argv[2]
+except:
+    usage()
+
+
+for a in list_artifacts(name, version):
+    print "%s: %s" % (a, humansize(get_bytes_length(name, version, a)))


### PR DESCRIPTION
With the migration of the landing downloads page to www.openmicroscopy.org and the usage of `_config.yml` to maintain the versions, the only manual step leftover while updating downloads pages following a release remains the update of the artifact sizes.

129df8f adds a Python script which goes through all the artifacts of a released product, reads the `ContentLength` from the header opened with `urllib2` and formats it as a human-readable size using the same logic as in https://github.com/openmicroscopy/ome-release/blob/develop/doc_generator.py.

4d74113 is a manual update of the Bio-Formats downloads page using the return from `python gen_sizes.py bio-formats 5.6.0`

Open questions:
- the current request uses the default `urllib2` header e.g. `Python-urllib/2.7`. Should we update this to filter these downloads requests or is it handled via the IP filtering?
- thoughts about trying to maintain more of these parameters in `_config.yml` and expanding `gen_sizes.py` generate a YML block e.g.

```
bf:
 version: 5.6.0
 bioformats_package: 31.71 MB
 bftools: 30.03 MB
```



