### PR TITLE
Change original OME citation & add crossref

### DIFF
--- a/citing-ome/index.html
+++ b/citing-ome/index.html
@@ -76,11 +76,11 @@ title: Citing OME
         <hr class="whitespace">
         <div class="row">
             <div class="small-12 medium-4 columns">
-                <h3>The Original OME Server</h3>
+                <h3>The original OME vision</h3>
             </div>
             <div class="small-12 medium-8 columns">
-                <p class="citation">Johnston, J., Nagaraja, A., Hochheiser, H., and Goldberg, I. G. (2006) A Flexible Framework for Web Interfaces to Image Databases: Supporting User-Defined Ontologies and Links to External Databases. 2006 IEEE International Symposium on Biomedical Imaging.</p>
-                <p><a href="http://ieeexplore.ieee.org/xpls/abs_all.jsp?arnumber=1625184" target="_blank">doi: 10.1109/ISBI.2006.1625184</a></p>
+                <p class="citation">Swedlow JR, Goldberg I, Brauner E, Sorger PK (2003) Informatics and quantitative analysis in biological imaging. Science 300(5616), 100-2. Published 4 April 2003</p>
+                <p><a href="https://www.ncbi.nlm.nih.gov/pubmed/12677061" target="_blank">PMID: 12677061</a></p>
             </div>            
         </div>
         <!-- end citation-->

--- a/licensing/index.html
+++ b/licensing/index.html
@@ -18,6 +18,7 @@ title: Licensing
         <div class="row column">
             <p>All OME formats and software are freely available, and all OMERO and Bio-Formats source code is available under GNU public “copyleft” licenses or more permissive open source licenses, or through commercial license from <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a>.</p>
             <p>For questions about the GNU license refer to the <a href="http://www.gnu.org/licenses/gpl-faq.html" target="_blank">Frequently Asked Questions about the GNU Licenses</a> page.</p>
+            <p>Please <a href="{{ site.baseurl }}/citing-ome/">cite our work</a> in your own publications to help us secure grant funding for future development of OME products.</p>
         </div>
         <!-- end -->
         


### PR DESCRIPTION
See https://trello.com/c/DR1L8nDA/100-add-citations

This changes the final citation as suggested by Jason and I've also added a cross-reference to the top of the licensing page

Staged at https://snoopycrimecop.github.io/www.openmicroscopy.org/citing-ome/ and https://snoopycrimecop.github.io/www.openmicroscopy.org/licensing/