### PR TITLE
Add Github links for the 2014-SV2 & 2016-SV2 SQL scripts

### DIFF
--- a/security/2014-SV2-empty-passwords/index.html
+++ b/security/2014-SV2-empty-passwords/index.html
@@ -49,12 +49,12 @@ main-blurb: affects OMERO4 versions 4.4.11 and earlier and OMERO5 versions 5.0.4
                     Use the provided SQL to disable affected accounts and the provided patches to prevent further empty password creation.</p>
                 <p class="secvul-description">
                     Warning: After running the following SQL, <strong>users with empty passwords will be immediately locked out</strong>.
-                    Either</p>
+                    Either:</p>
                 <ul>
                     <li><a href="https://raw.githubusercontent.com/openmicroscopy/openmicroscopy/v.5.0.5/sql/psql/OMERO5.0__0/2014-SV2-empty-passwords-list.sql" target="_blank">2014-SV2-empty-passwords-list.sql</a> (5.0), or</li>
                     <li><a href="https://raw.githubusercontent.com/openmicroscopy/openmicroscopy/v.4.4.12/sql/psql/OMERO4.4__0/2014-SV2-empty-passwords-list.sql" target="_blank">2014-SV2-empty-passwords-list.sql</a> (4.4)</li>
                 </ul>
-                <p class="secvul-description">will list the users which are affected. To lock accounts, use either:</p>
+                <p class="secvul-description">will list the users who are affected. To lock accounts, use either:</p>
                 <ul>
                     <li><a href="https://raw.githubusercontent.com/openmicroscopy/openmicroscopy/v.5.0.5/sql/psql/OMERO5.0__0/2014-SV2-empty-passwords-fix.sql" target="_blank">2014-SV2-empty-passwords-fix.sql</a> (5.0), or</li>
                     <li><a href="https://raw.githubusercontent.com/openmicroscopy/openmicroscopy/v.4.4.12/sql/psql/OMERO4.4__0/2014-SV2-empty-passwords-fix.sql" target="_blank">2014-SV2-empty-passwords-fix.sql</a> (4.4)</li>

--- a/security/2014-SV2-empty-passwords/index.html
+++ b/security/2014-SV2-empty-passwords/index.html
@@ -51,13 +51,13 @@ main-blurb: affects OMERO4 versions 4.4.11 and earlier and OMERO5 versions 5.0.4
                     Warning: After running the following SQL, <strong>users with empty passwords will be immediately locked out</strong>.
                     Either</p>
                 <ul>
-                    <li><code>sql/psql/OMERO5.0__0/2014-SV2-empty-passwords-list.sql</code> (5.0.5), or</li>
-                    <li><code>sql/psql/OMERO4.4__0/2014-SV2-empty-passwords-list.sql</code> (4.4.12)</li>
+                    <li><a href="https://raw.githubusercontent.com/openmicroscopy/openmicroscopy/v.5.0.5/sql/psql/OMERO5.0__0/2014-SV2-empty-passwords-list.sql" target="_blank">2014-SV2-empty-passwords-list.sql</a> (5.0), or</li>
+                    <li><a href="https://raw.githubusercontent.com/openmicroscopy/openmicroscopy/v.4.4.12/sql/psql/OMERO4.4__0/2014-SV2-empty-passwords-list.sql" target="_blank">2014-SV2-empty-passwords-list.sql</a> (4.4)</li>
                 </ul>
                 <p class="secvul-description">will list the users which are affected. To lock accounts, use either:</p>
                 <ul>
-                    <li><code>sql/psql/OMERO5.0__0/2014-SV2-empty-passwords-fix.sql</code> (5.0.5), or</li>
-                    <li><code>sql/psql/OMERO4.4__0/2014-SV2-empty-passwords-fix.sql</code> (4.4.12)</li>
+                    <li><a href="https://raw.githubusercontent.com/openmicroscopy/openmicroscopy/v.5.0.5/sql/psql/OMERO5.0__0/2014-SV2-empty-passwords-fix.sql" target="_blank">2014-SV2-empty-passwords-fix.sql</a> (5.0), or</li>
+                    <li><a href="https://raw.githubusercontent.com/openmicroscopy/openmicroscopy/v.4.4.12/sql/psql/OMERO4.4__0/2014-SV2-empty-passwords-fix.sql" target="_blank">2014-SV2-empty-passwords-fix.sql</a> (4.4)</li>
                 </ul>
                 <p class="secvul-description">For a quick check, use this SQL:</p>
                     <pre><code class="html">select e.id,

--- a/security/2016-SV2-share/index.html
+++ b/security/2016-SV2-share/index.html
@@ -47,10 +47,10 @@ main-blurb: affects OMERO versions 5.2.4 and earlier
                 <h3 class="secvul-heading"><i class="fa fa-lightbulb-o"></i> Workaround</h3>
             </div>
             <div class="small-12 medium-9 columns">
-                <p class="secvul-description"><a href="http://downloads.openmicroscopy.org/resources/" target="_blank">SQL scripts are provided for the 5.1 and 5.2 databases</a> which:</p>
+                <p class="secvul-description">Use either the provided SQL scripts to delete all shares and disable the creation of shares:</p>
                 <ul>
-                    <li>delete all shares</li>
-                    <li>disable the creation of shares</li>
+                    <li><a href="https://raw.githubusercontent.com/openmicroscopy/openmicroscopy/v5.2.5/sql/psql/OMERO5.2__0/OMERO5.2-delete-and-disable-shares.sql" target="_blank">OMERO5.2-delete-and-disable-shares.sql</a> (5.2), or</li>
+                    <li><a href="https://raw.githubusercontent.com/openmicroscopy/openmicroscopy/v5.2.5/sql/psql/OMERO5.1__1/OMERO5.1-delete-and-disable-shares.sql" target="_blank">OMERO5.1-delete-and-disable-shares.sql</a> (5.1).</li>
                 </ul>
                 <p class="secvul-description">These scripts can be run against a running server with no downtime. If you are not actively using the shares functionality, this is a safe course of action. To see if your users have created any shares use:</p>
                 <pre><code class="html">psql omero -c "select count(*) from share"</code></pre>

--- a/security/2016-SV2-share/index.html
+++ b/security/2016-SV2-share/index.html
@@ -47,7 +47,7 @@ main-blurb: affects OMERO versions 5.2.4 and earlier
                 <h3 class="secvul-heading"><i class="fa fa-lightbulb-o"></i> Workaround</h3>
             </div>
             <div class="small-12 medium-9 columns">
-                <p class="secvul-description">Use either the provided SQL scripts to delete all shares and disable the creation of shares:</p>
+                <p class="secvul-description">Use either of the provided SQL scripts to delete all shares and disable the creation of shares:</p>
                 <ul>
                     <li><a href="https://raw.githubusercontent.com/openmicroscopy/openmicroscopy/v5.2.5/sql/psql/OMERO5.2__0/OMERO5.2-delete-and-disable-shares.sql" target="_blank">OMERO5.2-delete-and-disable-shares.sql</a> (5.2), or</li>
                     <li><a href="https://raw.githubusercontent.com/openmicroscopy/openmicroscopy/v5.2.5/sql/psql/OMERO5.1__1/OMERO5.1-delete-and-disable-shares.sql" target="_blank">OMERO5.1-delete-and-disable-shares.sql</a> (5.1).</li>


### PR DESCRIPTION
These scripts are available under the server sql folder in the versions following the security fix. This PR also updates the security pages to link to SQL scripts using the raw GitHub URLs.