### PR TITLE
Update web install doc link for 5.4.0

### DIFF
--- a/omero/downloads/index.html
+++ b/omero/downloads/index.html
@@ -113,7 +113,7 @@ title: OMERO Downloads
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_python.svg">
                         <h5>Python (Ice 3.6)</h5>
                         <h6>OMERO.py-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip</h6>
-                        <p class="card-caption">OMERO.py can be used to install OMERO.web decoupled from the OMERO.server, see the <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/unix/install-web.html">OMERO.web documentation</a> for details.</p>
+                        <p class="card-caption">OMERO.py can be used to install OMERO.web decoupled from the OMERO.server, see the <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/unix/install-web/web-deployment.html">OMERO.web documentation</a> for details.</p>
                         <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.py-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (9.09 MB)</a>
                     </div>
                 </div>


### PR DESCRIPTION
With the doc rearrangement in https://github.com/openmicroscopy/ome-documentation/pull/1739 this link needs updating to help point sysadmins to the right place for 5.4.0.