### PR TITLE
clean up security landing page

### DIFF
--- a/security/index.html
+++ b/security/index.html
@@ -16,7 +16,7 @@ main-blurb: Keeping your data secure
                 <p>If you discover a security vulnerability or would like to report a security issue privately and securely, please <a href="mailto:security@openmicroscopy.org.uk">email us</a>. You can use GPG keys to communicate with us securely. If you do, please upload your GPG public key or supply it to us in some other way, so that we can reply securely too:</p>
                 <div class="callout primary small-12 medium-5">
                     <ul class="fa-ul">
-                      <li><i class="fa-li fa fa-1x fa-envelope"></i><span class="card-caption">security@openmicroscopy.org.uk</span></li>
+                      <li><i class="fa-li fa fa-1x fa-envelope"></i><span class="card-caption">security@openmicroscopy.org</span></li>
                       <li><i class="fa-li fa fa-1x fa-key"></i><span class="card-caption">GPG key</span></li>
                       <li><i class="fa-li fa fa-1x fa-id-card-o"></i><span class="card-caption">D66A 021D 3B7F 70DB CCBB 1D89 C46E 96E6 13ED 38AF</span></li>
                     </ul>

--- a/security/index.html
+++ b/security/index.html
@@ -6,25 +6,29 @@ main-blurb: Keeping your data secure
 ---                      
 
         
-        <!-- end Security -->
+        <!-- begin Security -->
         <hr class="whitespace">
         <div id="secvuln-reporting" class="row">
-            <p>See our <a href="{{ site.baseurl }}/security/advisories/">archive of past security advisories</a>.</p>
-            <div class="small-12">
-                <div class="callout primary">
-                    <p>If you discover a security vulnerability or would like to report a security issue privately and securely, please <a href="mailto:security@openmicroscopy.org.uk">email us</a>. You can use GPG keys to communicate with us securely. If you do, please upload your GPG public key or supply it to us in some other way, so that we can reply securely too:</p>
+            <div class="column small-12">
+                <h2>Security Advisories</h2>
+                <p>See our archive of <a href="{{ site.baseurl }}/security/advisories/">past security advisories</a>.</p>                
+                <h2>How to Report a Security Vulnerability</h2>
+                <p>If you discover a security vulnerability or would like to report a security issue privately and securely, please <a href="mailto:security@openmicroscopy.org.uk">email us</a>. You can use GPG keys to communicate with us securely. If you do, please upload your GPG public key or supply it to us in some other way, so that we can reply securely too:</p>
+                <div class="callout primary small-12 medium-5">
                     <ul class="fa-ul">
                       <li><i class="fa-li fa fa-1x fa-envelope"></i><span class="card-caption">security@openmicroscopy.org.uk</span></li>
                       <li><i class="fa-li fa fa-1x fa-key"></i><span class="card-caption">GPG key</span></li>
                       <li><i class="fa-li fa fa-1x fa-id-card-o"></i><span class="card-caption">D66A 021D 3B7F 70DB CCBB 1D89 C46E 96E6 13ED 38AF</span></li>
-                    </ul>              
-                    <p>OME takes its responsibility to help keep our users’ data secure very seriously. We strongly encourage people to report any security issues to our private security mailing list.</p>
-                    <p>Emails sent to us are read and acknowledged with a non-automated response. For issues that are complicated and require significant attention, we will open an investigation and keep you informed of our progress.</p>
-                    <p>Details will only be released to the public once we have a fix in place.</p>
-                    <p>Please note that the security mailing list should only be used for reporting undisclosed security vulnerabilities in OME products and managing the process of fixing such vulnerabilities. We cannot accept bug reports or other queries at this address. All mail sent to this address that does not relate to a security problem will be ignored.</p>                
-                    <p>For bug reports and other issues, please use our public mailing lists and forums.</p>
-                </div>
+                    </ul>
+                </div>              
+                <p>OME takes its responsibility to help keep our users’ data secure very seriously. We strongly encourage people to report any security issues to our private security mailing list.</p>
+                <h2>Our Process</h2>
+                <p>Emails sent to us are read and acknowledged with a non-automated response. For issues that are complicated and require significant attention, we will open an investigation and keep you informed of our progress.</p>
+                <p>Details will only be released to the public once we have a fix in place.</p>
+                <p>Please note that the security mailing list should only be used for reporting undisclosed security vulnerabilities in OME products and managing the process of fixing such vulnerabilities. We cannot accept bug reports or other queries at this address. All mail sent to this address that does not relate to a security problem will be ignored.</p>                
+                <p>For bug reports and other issues, please use our public mailing lists and forums.</p>
             </div>
         </div>       
         <hr class="invisible">
+        <!-- end Security -->
         

--- a/security/index.html
+++ b/security/index.html
@@ -13,7 +13,7 @@ main-blurb: Keeping your data secure
                 <h2>Security Advisories</h2>
                 <p>See our archive of <a href="{{ site.baseurl }}/security/advisories/">past security advisories</a>.</p>                
                 <h2>How to Report a Security Vulnerability</h2>
-                <p>If you discover a security vulnerability or would like to report a security issue privately and securely, please <a href="mailto:security@openmicroscopy.org.uk">email us</a>. You can use GPG keys to communicate with us securely. If you do, please upload your GPG public key or supply it to us in some other way, so that we can reply securely too:</p>
+                <p>If you discover a security vulnerability or would like to report a security issue privately and securely, please <a href="mailto:security@openmicroscopy.org">email us</a>. You can use GPG keys to communicate with us securely. If you do, please upload your GPG public key or supply it to us in some other way, so that we can reply securely too:</p>
                 <div class="callout primary small-12 medium-5">
                     <ul class="fa-ul">
                       <li><i class="fa-li fa fa-1x fa-envelope"></i><span class="card-caption">security@openmicroscopy.org</span></li>


### PR DESCRIPTION
Since the advisories were moved to their own separate page, the blue callout box no longer works for this layout.

This cleans up the landing page so that the content's visual hierarchy is more clear.