### PR TITLE
Update secvuln page links on release announcements

### DIFF
--- a/_posts/2014-09-25-omero-bio-formats-5-0-5.md
+++ b/_posts/2014-09-25-omero-bio-formats-5-0-5.md
@@ -6,7 +6,7 @@ intro-blurb: The OME team is pleased to announce the release of OMERO & Bio-Form
 Two security vulnerabilities have been discovered in versions of OMERO up to and including 4.4.11
 and up to and including 5.0.4.
 
-**System administrators should review the [Security Vulnerabilities pages](https://www.openmicroscopy.org/site/products/omero/secvuln) on the OME website**
+**System administrators should review the [Security Advisories page]({{ site.baseurl }}/security/advisories/) on the OME website**
 
 The more critical of the two, 2014-SV2, provides a workaround which can and should be applied immediately.
 
@@ -17,10 +17,10 @@ respective downloads page:
  - [archived downloads](https://downloads.openmicroscopy.org/omero/5.0.5/)
  - [archived downloads](https://downloads.openmicroscopy.org/omero/4.4.12/)
 
-For information on the upgrade from 4.4.x or 5.0.x to 5.0.5, see the [OMERO 5 instructions](https://www.openmicroscopy.org/site/support/omero5.0/sysadmins/server-upgrade.html)
+For information on the upgrade from 4.4.x or 5.0.x to 5.0.5, see the [OMERO 5 instructions](https://docs.openmicroscopy.org/omero/5.0.5/sysadmins/server-upgrade.html)
 
 For information on the upgrade from 4.4.x to 4.4.12, see the OMERO4 instructions, but upgrading
-directly to 5.0.5 would be preferred, see [server upgrade](https://www.openmicroscopy.org/site/support/omero4/sysadmins/server-upgrade.html)
+directly to 5.0.5 would be preferred, see [server upgrade](https://docs.openmicroscopy.org/omero/4.4.12/sysadmins/server-upgrade.html)
 
 Note that version 4.4.12 introduces the same password salting that is used in the 5.0 series.
 The implications of this improvement to server security are described in a warning among the

--- a/_posts/2014-11-11-omero-bio-formats-5-0-6.md
+++ b/_posts/2014-11-11-omero-bio-formats-5-0-6.md
@@ -11,7 +11,7 @@ We do not consider either 2014-SV3 CSRF or 2014-SV4 POODLE to be critical vulner
 
 The new version is available [archived downloads](https://downloads.openmicroscopy.org/omero/5.0.6/)
 
-For information on the upgrade from 4.4.x or 5.0.x to 5.0.6, see the [OMERO 5 instructions](https://docs.openmicroscopy.org/omero/5.0.0/sysadmins/server-upgrade.html)
+For information on the upgrade from 4.4.x or 5.0.x to 5.0.6, see the [OMERO 5.0.6 instructions](https://docs.openmicroscopy.org/omero/5.0.6/sysadmins/server-upgrade.html)
 
 
 Bio-Formats 5.0.6 is also being released, although not due to a security vulnerability. Bug fixes include:

--- a/_posts/2014-11-11-omero-bio-formats-5-0-6.md
+++ b/_posts/2014-11-11-omero-bio-formats-5-0-6.md
@@ -4,14 +4,14 @@ title: Release of OMERO & Bio-Formats 5.0.6
 intro-blurb: The OME team is pleased to announce the release of OMERO & Bio-Formats 5.0.6
 ---
 Two security vulnerabilities have been discovered in versions of OMERO up to and including 5.0.5.
-**System administrators should review the [Security Vulnerabilities pages](https://www.openmicroscopy.org/site/products/omero/secvuln) on the OME website**
+**System administrators should review the [Security Advisories]({{ site.baseurl }}/security/advisories/) on the OME website**
 
 
 We do not consider either 2014-SV3 CSRF or 2014-SV4 POODLE to be critical vulnerabilities due to the difficulty of exploiting them. **However, we do highly recommend all installations be upgraded.**
 
 The new version is available [archived downloads](https://downloads.openmicroscopy.org/omero/5.0.6/)
 
-For information on the upgrade from 4.4.x or 5.0.x to 5.0.6, see the [OMERO 5 instructions](https://www.openmicroscopy.org/site/support/omero5.0/sysadmins/server-upgrade.html)
+For information on the upgrade from 4.4.x or 5.0.x to 5.0.6, see the [OMERO 5 instructions](https://docs.openmicroscopy.org/omero/5.0.0/sysadmins/server-upgrade.html)
 
 
 Bio-Formats 5.0.6 is also being released, although not due to a security vulnerability. Bug fixes include:

--- a/_posts/2016-05-30-omero-5-2-4.md
+++ b/_posts/2016-05-30-omero-5-2-4.md
@@ -9,7 +9,7 @@ which was not properly respecting user permissions and may lead to
 data loss.
 
 Full details of the issue are available on the
-[2016-SV1-cleanse](https://www.openmicroscopy.org/site/products/omero/secvuln/2016-SV1-cleanse)
+[2016-SV1-cleanse]({{ site.baseurl }}/security/advisories/2016-SV1-cleanse/)
 page.
 
 The script and command have now been made admin-only. It is highly

--- a/_posts/2016-08-02-omero-5-2-5.md
+++ b/_posts/2016-08-02-omero-5-2-5.md
@@ -8,7 +8,7 @@ the OMERO.shares API which was bypassing intended security
 restrictions and granting elevated privileges to read
 otherwise-restricted data.
 
-Full details of the issue are available here: [2016-SV2-share]({{ site.baseurl }}/security/advisories/2016-SV/2016-SV2-share/).
+Full details of the issue are available here: [2016-SV2-share]({{ site.baseurl }}/security/advisories/2016-SV2-share/).
 
 This release **does not** upgrade the version of Bio-Formats which
 OMERO uses.

--- a/_posts/2016-08-02-omero-5-2-5.md
+++ b/_posts/2016-08-02-omero-5-2-5.md
@@ -8,7 +8,7 @@ the OMERO.shares API which was bypassing intended security
 restrictions and granting elevated privileges to read
 otherwise-restricted data.
 
-Full details of the issue are available here: [2016-SV2-share](https://www.openmicroscopy.org/site/products/omero/secvuln/2016-SV2-share).
+Full details of the issue are available here: [2016-SV2-share]({{ site.baseurl }}/security/advisories/2016-SV/2016-SV2-share/).
 
 This release **does not** upgrade the version of Bio-Formats which
 OMERO uses.

--- a/_posts/2017-03-23-omero-5-2-8.md
+++ b/_posts/2017-03-23-omero-5-2-8.md
@@ -7,9 +7,9 @@ Today we are releasing OMERO 5.2.8. This is a security release to prevent users 
 
 Full details of the issues are available on:
 
--  [2017-SV1 Filename Mutability](https://www.openmicroscopy.org/site/products/omero/secvuln/2017-SV1-filename)
--  [2017-SV2 Edit in RW Group](https://www.openmicroscopy.org/site/products/omero/secvuln/2017-SV2-edit-rw)
--  [2017-SV3 Delete Script](https://www.openmicroscopy.org/site/products/omero/secvuln/2017-SV3-delete-script)
+-  [2017-SV1 Filename Mutability]({{ site.baseurl }}/security/advisories/2017-SV1-filename/)
+-  [2017-SV2 Edit in RW Group]({{ site.baseurl }}/security/advisories/2017-SV2-edit-rw/)
+-  [2017-SV3 Delete Script]({{ site.baseurl }}/security/advisories/2017-SV3-delete-script/)
 
 This release does not upgrade the version of Bio-Formats which OMERO uses.
 


### PR DESCRIPTION
This updates the links on the release announcements for security releases to point at the new pages now they are live.