### PR TITLE
Add previous to download footers &fix OMERO components link

### DIFF
--- a/bio-formats/downloads/index.html
+++ b/bio-formats/downloads/index.html
@@ -113,6 +113,7 @@ title: Bio-Formats Downloads
                 <div class="small-12 columns bg-image-text-container-cta text-center">
                     <p class="hero-subheader">All components available for this version of Bio-Formats are available here:</p>
                     <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/?C=M;O=D" class="large btn-red button sites-button hide-for-small-only" style="text-shadow: none;">Download Components</a>
+                    <p class="hero-subheader">Previous versions are available via the <a href="http://downloads.openmicroscopy.org/bio-formats/">downloads index</a></p>
                 </div>
             </div>
         </header>

--- a/ome-files/downloads/index.html
+++ b/ome-files/downloads/index.html
@@ -186,6 +186,7 @@ title: OME Files Downloads
                     <p class="hero-subheader">All components available for this version of OME Files are available here:</p>
                     <a href="https://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/sources" class="large btn-blue button sites-button" style="margin-right: 10px; text-shadow: none;">Download Sources</a>
                     <a href="https://downloads.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/{{ site.omefiles.build }}/tools" class="large btn-blue button sites-button" style="text-shadow: none;">Download Tools</a>
+                    <p class="hero-subheader">Previous versions are available via the <a href="http://downloads.openmicroscopy.org/ome-files-cpp/">downloads index</a></p>
                 </div>
             </div>
         </header>

--- a/omero/downloads/index.html
+++ b/omero/downloads/index.html
@@ -156,7 +156,8 @@ title: OMERO Downloads
             <div class="row">
                 <div class="small-12 columns bg-image-text-container-cta text-center">
                     <p class="hero-subheader">All components available for this version of OMERO are available here:</p>
-                    <a href="http://downloads.openmicroscopy.org/omero/5.3.2/artifacts/?C=N;O=A" class="large btn-red button sites-button" style="text-shadow: none;">Download Components</a>
+                    <a href="http://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/?C=N;O=A" class="large btn-red button sites-button" style="text-shadow: none;">Download Components</a>
+                    <p class="hero-subheader">Previous versions are available via the <a href="http://downloads.openmicroscopy.org/omero/">downloads index</a></p>
                 </div>
             </div>
         </header>


### PR DESCRIPTION
See https://trello.com/c/ALSwsNNV/91-add-previous-navigation

This adds a link to the downloads index to the bottom of each downloads page below the full components button.

I also fixed the OMERO components button link which wasn't using the auto version replacement so was therefore still pointing at 5.3.2.