### PR TITLE
Contributors

### DIFF
--- a/bio-formats/index.html
+++ b/bio-formats/index.html
@@ -55,7 +55,7 @@ title: Bio-Formats
         </div>
         <hr>
         <div class="row column text-center">
-            <p>Bio-Formats is a community project and we welcome your input. You can find guidance on <a href="https://docs.openmicroscopy.org/bio-formats/{{ site.bf.version }}/about/bug-reporting.html" target="_blank">reporting a bug</a>, upload files to our <a href="http://qa.openmicroscopy.org.uk/qa/upload/" target="_blank">QA system</a> for testing, and contact us via our mailing lists or forums. Further information about how the OME team works and how you can contribute to our projects is in the <a href="https://docs.openmicroscopy.org/contributing/" target="_blank">Contributing Developer Documentation</a>.</p>
+            <p>Bio-Formats is a community project and we welcome <a href="{{ site.baseurl }}/contributors/">your input</a>. You can find guidance on <a href="https://docs.openmicroscopy.org/bio-formats/{{ site.bf.version }}/about/bug-reporting.html" target="_blank">reporting a bug</a>, upload files to our <a href="http://qa.openmicroscopy.org.uk/qa/upload/" target="_blank">QA system</a> for testing, and contact us via our mailing lists or forums. Further information about how the OME team works and how you can contribute to our projects is in the <a href="https://docs.openmicroscopy.org/contributing/" target="_blank">Contributing Developer Documentation</a>.</p>
         </div>
         <!-- end -->
         

--- a/contributors/index.html
+++ b/contributors/index.html
@@ -41,6 +41,10 @@ title: Contributors
             </div>
             
             <div class="large-expand columns">
+            Leon Kolchinsky <a target="_blank" href="http://monash.edu/">Monash University</a>
+            </div>
+            
+            <div class="large-expand columns">
             Daniel Matthews <a target="_blank" href="http://nic.kcl.ac.uk">Nikon Imaging Centre, Kings College London</a> <a target="_blank" href="https://qbi.uq.edu.au">(formerly Queensland Brain Institute)</a>
             </div>
             
@@ -53,7 +57,7 @@ title: Contributors
             </div>
             
             <div class="large-expand columns">
-            Stephen Welsh (previously Leon Kolchinsky) <a target="_blank" href="http://monash.edu/">Monash University</a>
+            Stephen Welsh <a target="_blank" href="http://monash.edu/">Monash University</a>
             </div>
             
             <div class="large-expand columns">
@@ -181,6 +185,10 @@ title: Contributors
             </div>
             
             <div class="large-expand columns">
+            Stefan Helfrich <a target="_blank" href="https://www.uni-konstanz.de/en/">University of Konstanz</a>
+            </div>
+            
+            <div class="large-expand columns">
             Bill Hill <a target="_blank" href="http://www.hgu.mrc.ac.uk/index.html">Institute of Genetics &amp; Molecular Medicine, University of Edinburgh</a>
             </div>
             
@@ -273,6 +281,10 @@ title: Contributors
             </div>
             
             <div class="large-expand columns">
+            Alexander Popiel <a target="_blank" href="https://www.alleninstitute.org/what-we-do/cell-science/">Allen Institute for Cell Science</a>
+            </div>
+            
+            <div class="large-expand columns">
             Ville Rantanen <a target="_blank" href="http://www.helsinki.fi/university/">University of Helsinki</a>
             </div>
             
@@ -309,11 +321,11 @@ title: Contributors
             </div>
             
             <div class="large-expand columns">
-            Manuel Stritt <a target="_blank" href="https://www.actelion.com"> Actelion Pharmaceuticals Ltd</a>
+            Jakub Straszewski <a target="_blank" href="http://www.bsse.ethz.ch">Department of Biosystems Science &amp; Engineering, ETH Zurich</a>
             </div>
             
             <div class="large-expand columns">
-            Jakub Straszewski <a target="_blank" href="http://www.bsse.ethz.ch">Department of Biosystems Science &amp; Engineering, ETH Zurich</a>
+            Manuel Stritt <a target="_blank" href="https://www.actelion.com"> Actelion Pharmaceuticals Ltd</a>
             </div>
             
             <div class="large-expand columns">
@@ -325,7 +337,7 @@ title: Contributors
             </div>
             
             <div class="large-expand columns">
-            Paul Van Schayck <a target="_blank" href="http://www.maastrichtuniversity.nl/">Maastricht University</a>
+            Nicholas Trahearn <a target="_blank" href="http://www.icr.ac.uk/">The Institute of Cancer Research, London</a>
             </div>
             
             <div class="large-expand columns">
@@ -333,15 +345,9 @@ title: Contributors
             </div>
             
             <div class="large-expand columns">
-                Stefan Helfrich <a target="_blank" href="https://www.uni-konstanz.de/en/">University of Konstanz</a>
+            Paul Van Schayck <a target="_blank" href="http://www.maastrichtuniversity.nl/">Maastricht University</a>
             </div>
             
-            <div class="large-expand columns">
-                Nicholas Trahearn <a target="_blank" href="http://www.icr.ac.uk/">The Institute of Cancer Research, London</a>
-            </div>
-            <div class="large-expand columns">
-                Alexander Popiel <a target="_blank" href="https://www.alleninstitute.org/what-we-do/cell-science/">Allen Institute for Cell Science</a>
-            </div>
             <div class="large-expand columns">
                 Thushara Wijeratna <a target="_blank" href="https://www.alleninstitute.org/what-we-do/cell-science/">Allen Institute for Cell Science</a>
             </div>


### PR DESCRIPTION
See https://trello.com/c/r5mG4Wm2/110-contributors-page
This restores the BF contributors list to being alphabetical, lists the Monash OMERO contributors separately and adds a link to the contributors list to the BF product page (there doesn't seem an obvious place to add it to the OMERO landing page and Mark realized he meant adding it to the *docs* About pages when I asked him.