### PR TITLE
Update links to scripting info

### DIFF
--- a/omero/analyze/index.html
+++ b/omero/analyze/index.html
@@ -47,7 +47,7 @@ usergroup: omero
                 <h4>Scripting service</h4>
                 <p>Write scripts to add functionality to OMERO.server
                     and share them with the community.</p>
-                <a class="button hollow tiny" href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/developers/index.html#omero-scripts-plugins-for-omero" target="_blank">View developer guide</a>
+                <a class="button hollow tiny" href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/developers/scripts/" target="_blank">View developer guide</a>
                 <a class="button hollow tiny" href="https://www.youtube.com/watch?v=sKRvYVZksdM" target="_blank">View movie</a>
             </div>
             <div class="omero-feature-container tall-content column text-center">

--- a/omero/developers/index.html
+++ b/omero/developers/index.html
@@ -68,8 +68,8 @@ usergroup: developers
             <div class="medium-1 columns"><img class="omero-feature thumbnail" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_scripts.svg"></div>
             <div class="omero-key-feature-container medium-3 columns end">
                 <h4>Scripting Service</h4>
-                <p>Write Python scripts to add functionality to the OMERO.server. <a href="https://www.openmicroscopy.org/site/community/scripts" target="_blank">Share your scripts</a> with the community.</p>
-                <a class="button hollow tiny" href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/developers/index.html#omero-scripts-plugins-for-omero" target="_blank">View Developer Guide</a>
+                <p>Write Python scripts to add functionality to the OMERO.server. <a href="https://github.com/ome/omero-user-scripts/network/members" target="_blank">Share your scripts</a> with the community.</p>
+                <a class="button hollow tiny" href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/developers/scripts/" target="_blank">View Developer Guide</a>
             </div>
         </div>
         <hr class="invisible">


### PR DESCRIPTION
In light of https://github.com/openmicroscopy/ome-documentation/pull/1802 and https://trello.com/c/2GbTdzSU/121-community-script-content this removes the link to the old scripts page on plone and updates the docs links to land people directly on the scripts index page, which will be updated for 5.4.1 to provide a better landing page and host all the content from the old plone page (barring the table of scripts which we have ditched).