### PR TITLE
Replace ansible example with link to repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install: bundle install
 script:
     - bundle exec jekyll build  -d _site/www.openmicroscopy.org
     - bundle exec htmlproofer ./_site --disable-external
-    - cd _includes; docker build -t omero-c7 .
-    - docker run --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -d --name omero-c7 omero-c7
-    - docker exec omero-c7 bash /tmp/omero-c7.sh
-    - echo TODO - add docker-compose test after merge
+    #- cd _includes; docker build -t omero-c7 .
+    #- docker run --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -d --name omero-c7 omero-c7
+    #- docker exec omero-c7 bash /tmp/omero-c7.sh
+    #- echo TODO - add docker-compose test after merge

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: ruby
-sudo: false
+sudo: required
 cache: bundler
 rvm: 2.3.3
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+services:
+  - docker
 install: bundle install
 script:
     - bundle exec jekyll build  -d _site/www.openmicroscopy.org
     - bundle exec htmlproofer ./_site --disable-external
+    - cd _includes; docker build -t omero-c7 .
+    - docker run --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -d --name omero-c7 omero-c7
+    - docker exec omero-c7 bash /tmp/omero-c7.sh
+    - echo TODO - add docker-compose test after merge

--- a/_includes/Dockerfile
+++ b/_includes/Dockerfile
@@ -1,0 +1,3 @@
+FROM centos/systemd
+COPY omero-c7.sh /tmp/
+CMD ["/usr/sbin/init"]

--- a/_includes/omero-c7.sh
+++ b/_includes/omero-c7.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+yum install -y -q epel-release
+yum install -y -q ansible sudo
+ansible-galaxy install \
+    openmicroscopy.postgresql \
+    openmicroscopy.omero-server \
+    openmicroscopy.omero-web
+cat << EOF > ~/omero-playbook.yml
+- hosts: localhost
+  roles:
+    - role: openmicroscopy.postgresql
+      postgresql_databases:
+      - name: omero
+      postgresql_users:
+      - user: omero
+        password: omero
+        databases: [omero]
+      postgresql_version: "9.6"
+    - role: openmicroscopy.omero-server
+      omero_server_rootpassword: ChangeMe
+    - role: openmicroscopy.omero-web
+EOF
+ansible-playbook ~/omero-playbook.yml

--- a/explore/index.html
+++ b/explore/index.html
@@ -46,18 +46,8 @@ title: Explore
                 <img alt="OMERO for Developers" src="{{ site.baseurl }}/img/icons/user-groups_developers.svg">
             </div>
             <div class="medium-4 medium-offset-1 column">
-                <h5 class="text-center">Start a Server with Ansible</h5>
-                <pre><code class="html"># Start a server with ansible
-ansible-galaxy install openmicroscopy.omero-server
-cat playbook.yml &lt;&lt;EOF
-- hosts: localhost
-  roles:
-  - role: openmicroscopy.omero-server
-    postgresql_users_databases:
-    - user: omero
-      password: omero
-      databases: [omero]
-EOF</code></pre>
+                <h5 class="text-center">Deploy an OMERO server with Ansible</h5>
+                <p>Ansible can deploy an OMERO.server with the same production configuration that we use in the OME. <a href="https://github.com/ome/ansible-examples-omero">Take a look at the examples in this repository.</a></p>
             </div>
             <div class="medium-4 column end">
                 <h5 class="text-center">Start a Server in Docker</h5>

--- a/explore/index.html
+++ b/explore/index.html
@@ -72,13 +72,18 @@ docker run -d --name omero-master --link postgres:db \
                 <ul class="dev-ops-links">
                     <li>Ansible examples:
                         <ul>
-                            <li><a href="https://github.com/openmicroscopy/ansible-public-omero-example">Public OMERO</a></li>
+                            <li><a href="https://github.com/ome/ansible-examples-omero/tree/master/public-user">Public OMERO</a></li>
                             <li><a href="https://github.com/openmicroscopy/ansible-role-omero-server">OMERO Server</a></li>
                             <li><a href="https://github.com/openmicroscopy/ansible-role-omero-web">OMERO Web</a></li>
                         </ul>
                     </li>
-                    <li><a href="https://github.com/openmicroscopy/omero-server-docker">Docker</a></li>
-                    <li><a href="https://anaconda.org/bioconda/python-omero">Python OMERO</a></li>
+                    <li>Docker examples:
+                        <ul>
+                            <li><a href="https://github.com/openmicroscopy/omero-server-docker">OMERO Server</a></li>
+                            <li><a href="https://github.com/openmicroscopy/omero-web-docker">OMERO Web</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="https://anaconda.org/bioconda/python-omero">or Python OMERO on Bioconda</a></li>
                 </ul>
             </div>
             <div class="medium-1 columns"><i class="icon-fa-blue fa fa-laptop fa-2x"></i></div>

--- a/explore/index.html
+++ b/explore/index.html
@@ -46,8 +46,11 @@ title: Explore
                 <img alt="OMERO for Developers" src="{{ site.baseurl }}/img/icons/user-groups_developers.svg">
             </div>
             <div class="medium-4 medium-offset-1 column">
-                <h5 class="text-center">Deploy an OMERO server with Ansible</h5>
-                <p>Ansible can deploy an OMERO.server with the same production configuration that we use in the OME. <a href="https://github.com/ome/ansible-examples-omero">Take a look at the examples in this repository.</a></p>
+                <h5 class="text-center">Deploy an OMERO server on CentOS 7 with Ansible</h5>
+                <p>Ansible can deploy an OMERO.server with the same production configuration that we use in the OME.
+                <a href="https://github.com/ome/ansible-examples-omero">Take a look at the examples in this repository.</a></p>
+                <pre><code class="html">{% include omero-c7.sh %}
+                </code></pre>
             </div>
             <div class="medium-4 column end">
                 <h5 class="text-center">Start a Server in Docker</h5>


### PR DESCRIPTION
The ansible example has been broken since it was first added to the explore page. This replaces it with a link to a working examples repo. In future we can reconsider whether to embed the example.

See https://github.com/openmicroscopy/www.openmicroscopy.org/pull/153#issuecomment-344257148