### PR TITLE
Bio-Formats 5.7.2 release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ paginate_path: "/announcements/page:num/"
 future: true
 
 bf:
- version: 5.7.1
+ version: 5.7.2
 
 omero:
  version: 5.4.0

--- a/_posts/2017-11-21-bio-formats-5-7-2.md
+++ b/_posts/2017-11-21-bio-formats-5-7-2.md
@@ -12,7 +12,7 @@ File format fixes and improvements:
       single channel images
 
 * MetaMorph TIFF
-    * changed the reader's behaviour to populate exposure times for all planes
+    * changed the reader's behavior to populate exposure times for all planes
       when only a single exposure time is defined
 
 * DeltaVision
@@ -45,7 +45,7 @@ Documentation improvements:
 * added a link to [Adding format/reader documentation pages](https://docs.openmicroscopy.org/latest/bio-formats/developers/format-documentation.html)
   to help those contributing to the documentation or supported formats pages
 * the [Bio-Rad Gel page](https://docs.openmicroscopy.org/latest/bio-formats/formats/bio-rad-gel.html) has been updated to add a link to biorad1sc_reader, an
-  external python implementation (thanks to Matthew Clapp)
+  external Python implementation (thanks to Matthew Clapp)
 
 Full details can be found at [Bio-Formats version history](https://docs.openmicroscopy.org/bio-formats/5.7.2/about/whats-new.html).
 

--- a/_posts/2017-11-21-bio-formats-5-7-2.md
+++ b/_posts/2017-11-21-bio-formats-5-7-2.md
@@ -1,0 +1,55 @@
+---
+layout: post
+title: Release of Bio-Formats 5.7.2
+intro-blurb: The OME team is pleased to announce the release of Bio-Formats 5.7.2
+---
+Today we are releasing Bio-Formats 5.7.2 which includes the following changes:
+
+File format fixes and improvements:
+
+* Nikon ND2
+    * fixed a bug which would use the incorrect channel count for small-sized
+      single channel images
+
+* MetaMorph TIFF
+    * changed the reader's behaviour to populate exposure times for all planes
+      when only a single exposure time is defined
+
+* DeltaVision
+    * improved parsing of the associated log files to add additional key value 
+      pairs to global metadata
+
+* EPS (Encapsulated PostScript)
+    * fixed an exception when reading pixel data in cases with embedded TIFF
+
+* GIF
+    * fixed a bug to display the correct data when reading planes out of order
+
+Bug fixes and improvements:
+
+* fixed failures with Ant build from a clean Maven repository by updating
+  Maven repositories to use HTTPS rather than HTTP
+* now using safe version checking for Bio-Formats plugins to prevent a bug
+  with Java 9
+* updated the JPEG-XR codec to allow either interleaved or non-interleaved
+  data to be returned
+
+Documentation improvements:
+
+* added clarification regarding Bio-Formats version requirements for using
+  Java 7 or above
+* updated download links to latest Bio-Formats release version
+* updated the link to the most active fork of JAI ImageIO
+* fixed a number of external broken links
+* added a Trello link for contributing external developers
+* added a link to [Adding format/reader documentation pages](https://docs.openmicroscopy.org/latest/bio-formats/developers/format-documentation.html)
+  to help those contributing to the documentation or supported formats pages
+* the [Bio-Rad Gel page](https://docs.openmicroscopy.org/latest/bio-formats/formats/bio-rad-gel.html) has been updated to add a link to biorad1sc_reader, an
+  external python implementation (thanks to Matthew Clapp)
+
+Full details can be found at [Bio-Formats version history](https://docs.openmicroscopy.org/bio-formats/5.7.2/about/whats-new.html).
+
+The software is available at [archived downloads](https://downloads.openmicroscopy.org/bio-formats/5.7.2)
+and will shortly be available from the Java-8 update site for Fiji users.
+
+Any problems or comments, please use the [OME Forums or mailing lists]({{ site.baseurl }}/support/).

--- a/bio-formats/downloads/index.html
+++ b/bio-formats/downloads/index.html
@@ -5,7 +5,7 @@ title: Bio-Formats Downloads
         <div class="callout large primary" id="bg-image-bio-formats">
             <div class="row column text-center">
                 <h1>Bio-Formats {{ site.bf.version }} Downloads</h1>
-                <a href="{{ site.baseurl }}/2017/09/20/bio-formats-5-7-1.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
+                <a href="{{ site.baseurl }}/2017/11/21/bio-formats-5-7-2.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
                 <a href="https://docs.openmicroscopy.org/bio-formats/{{ site.bf.version }}/" target="_blank" class="hero-link">Read the Docs</a>
             </div>
         </div>

--- a/contributors/index.html
+++ b/contributors/index.html
@@ -125,6 +125,10 @@ title: Contributors
             </div>
             
             <div class="large-expand columns">
+            Matthew Clapp <a target="_blank" href="http://wavedrom.com">WaveDrom</a>
+            </div>
+            
+            <div class="large-expand columns">
             Tony Collins <a target="_blank" href="http://www.mcmaster.ca/">McMaster University</a>
             </div>
             


### PR DESCRIPTION
See https://trello.com/c/9Y0PGqsf/28-open-pr-against-wwwopenmicroscopyorg and https://github.com/openmicroscopy/bioformats/pull/3002

N.B. 5.7.2 links (docs & downloads) won't work until the release build is run