### PR TITLE
 Update ome-files docs links to new URLs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@ title: Docs
                         <div class="medium-2"><img class="thumbnail" alt="OME Files logo" src="{{ site.baseurl }}/img/logos/ome-files-logomark.svg"></div>
                         <h4>OME Files</h4>
                         <p class="card-caption" style="min-height: 148px;">This includes guidance for using the OME Files C++ implementation and the OME CMake Super-Build, as well as links to the API references.</p>
-                        <a href="https://www.openmicroscopy.org/site/support/ome-files-cpp/" target="_blank" class="tiny button hollow">Read on the Web <i class="fa fa-long-arrow-right"></i></a>
+                        <a href="https://docs.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/" target="_blank" class="tiny button hollow">Read on the Web <i class="fa fa-long-arrow-right"></i></a>
                     </div>
                 </div>
             </div>            

--- a/ome-files/downloads/index.html
+++ b/ome-files/downloads/index.html
@@ -5,7 +5,7 @@ title: OME Files Downloads
         <div class="callout large primary" id="bg-image-ome-files">
             <div class="row column text-center">
                 <h1>OME Files Downloads</h1>
-                <a href="https://www.openmicroscopy.org/site/support/ome-files-cpp/" target="_blank" class="hero-link">Read the Docs</a>
+                <a href="https://docs.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/" target="_blank" class="hero-link">Read the Docs</a>
             </div>
         </div>
         

--- a/ome-files/index.html
+++ b/ome-files/index.html
@@ -9,7 +9,7 @@ title: OME Files
                     <p class="hero-subheader small-12">The solution for developers to support the OME data model and OME-TIFF in their software</p>
                     <br>
                     <a href="{{ site.baseurl }}/ome-files/downloads/" class="large button sites-button btn-blue">Download Version {{ site.omefiles.version }}</a>
-                    <a href="https://www.openmicroscopy.org/site/support/ome-files-cpp/" target="_blank" class="hero-link">Read the Docs</a>
+                    <a href="https://docs.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/" target="_blank" class="hero-link">Read the Docs</a>
                 </div>
             </div>
         </header>
@@ -22,7 +22,7 @@ title: OME Files
         <hr>
         <div class="row column text-center">
             <p>OME Files is a reference implementation of the OME data model and the OME-TIFF file format for developers who wish to integrate support for the <a href="https://docs.openmicroscopy.org/ome-model/{{ site.omemodel.version }}/#the-data-model-in-detail" target="_blank">OME data model</a> and reading and writing the standard <a href="https://docs.openmicroscopy.org/ome-model/{{ site.omemodel.version }}/index.html#ome-tiff" target="_blank">OME-TIFF file format</a> into their software. Potential uses include export of images using OME-TIFF, saving of acquired image data in OME-TIFF, reading metadata and image data from OME-TIFF for visualization and analysis, or use of the data model metadata APIs for handling metadata.</p>
-            <p><a class="small button sites-button btn-blue" href="https://www.openmicroscopy.org/site/support/ome-files-cpp/" target="_blank">Read the Docs <i class="fa fa-long-arrow-right"></i></a></p>
+            <p><a class="small button sites-button btn-blue" href="https://docs.openmicroscopy.org/ome-files-cpp/{{ site.omefiles.version }}/" target="_blank">Read the Docs <i class="fa fa-long-arrow-right"></i></a></p>
         </div>
         <!-- end -->
         


### PR DESCRIPTION
With the 0.5.0 release, the docs.oo.org URL now serves the index page allowing users to navigate to all the docs sets from the single URL so we don't need the old /site/support/ URLs any more.