### PR TITLE
Add links to new publication doc

### DIFF
--- a/css/openmicroscopy.css
+++ b/css/openmicroscopy.css
@@ -290,6 +290,14 @@ a.hero-link {
             color: #fff;
 }
 
+p.hero-subheader > a {
+    color: #eceff1;
+    text-decoration: underline; }
+    a.hero-link:hover {
+                color: #fff;
+}
+    
+
 /* ========== header background images ==========*/
 .header {
     background: #000;

--- a/omero/index.html
+++ b/omero/index.html
@@ -12,7 +12,7 @@ usergroup: omero
                         OMERO handles all your images in a secure central
                         repository. You can <a href="{{ site.baseurl }}/omero/view/">view</a>, <a href="{{ site.baseurl }}/omero/organize/">organize</a>, <a href="{{ site.baseurl }}/omero/analyze/">analyze</a> and <a href="{{ site.baseurl }}/omero/organize/">share</a> your data from anywhere you
                         have internet access. Work with your images from a
-                        desktop app(Windows, Mac or Linux), from the web or
+                        desktop app (Windows, Mac or Linux), from the web or
                         from 3rd party software. Over 140 image file formats
                         supported, including all major microscope formats.
                     </p>

--- a/omero/index.html
+++ b/omero/index.html
@@ -8,14 +8,13 @@ usergroup: omero
                 <div class="small-12 columns">
                     <h1 class="hero-main-header"><img src="{{ site.baseurl }}/img/logos/omero-white.svg" alt="OMERO logo" class="logo-hero" /></h1>
                     <p class="hero-subheader small-12">
-                        From the microscope to <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/publication.html" target="blank">publication</a>,
+                        From the microscope to <a href="{{ site.baseurl }}/omero/publish/">publication</a>,
                         OMERO handles all your images in a secure central
-                        repository. You can view, organize, analyze
-                        and share your data from anywhere you have internet
-                        access. Work with your images from a desktop app
-                        (Windows, Mac or Linux), from the web or from 3rd
-                        party software. Over 140 image file formats supported,
-                        including all major microscope formats.
+                        repository. You can <a href="{{ site.baseurl }}/omero/view/">view</a>, <a href="{{ site.baseurl }}/omero/organize/">organize</a>, <a href="{{ site.baseurl }}/omero/analyze/">analyze</a> and <a href-"{ site.baseurl }}/omero/organize/">share</a> your data from anywhere you
+                        have internet access. Work with your images from a
+                        desktop app(Windows, Mac or Linux), from the web or
+                        from 3rd party software. Over 140 image file formats
+                        supported, including all major microscope formats.
                     </p>
                     <br>
                     <a href="{{ site.baseurl }}/omero/downloads/" class="large button sites-button btn-red">Download Version {{ site.omero.version }}</a>

--- a/omero/index.html
+++ b/omero/index.html
@@ -7,7 +7,16 @@ usergroup: omero
             <div class="row homepage text-center bg-image-text-container">
                 <div class="small-12 columns">
                     <h1 class="hero-main-header"><img src="{{ site.baseurl }}/img/logos/omero-white.svg" alt="OMERO logo" class="logo-hero" /></h1>
-                    <p class="hero-subheader small-12">From the microscope to publication, OMERO handles all your images in a secure central repository. You can view, organize, analyze and share your data from anywhere you have internet access. Work with your images from a desktop app (Windows, Mac or Linux), from the web or from 3rd party software. Over 140 image file formats supported, including all major microscope formats.</p>
+                    <p class="hero-subheader small-12">
+                        From the microscope to <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/publication.html" target="blank">publication</a>,
+                        OMERO handles all your images in a secure central
+                        repository. You can view, organize, analyze
+                        and share your data from anywhere you have internet
+                        access. Work with your images from a desktop app
+                        (Windows, Mac or Linux), from the web or from 3rd
+                        party software. Over 140 image file formats supported,
+                        including all major microscope formats.
+                    </p>
                     <br>
                     <a href="{{ site.baseurl }}/omero/downloads/" class="large button sites-button btn-red">Download Version {{ site.omero.version }}</a>
                     <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/" target="_blank" class="hero-link">Read the Docs</a>

--- a/omero/index.html
+++ b/omero/index.html
@@ -10,7 +10,7 @@ usergroup: omero
                     <p class="hero-subheader small-12">
                         From the microscope to <a href="{{ site.baseurl }}/omero/publish/">publication</a>,
                         OMERO handles all your images in a secure central
-                        repository. You can <a href="{{ site.baseurl }}/omero/view/">view</a>, <a href="{{ site.baseurl }}/omero/organize/">organize</a>, <a href="{{ site.baseurl }}/omero/analyze/">analyze</a> and <a href-"{{ site.baseurl }}/omero/organize/">share</a> your data from anywhere you
+                        repository. You can <a href="{{ site.baseurl }}/omero/view/">view</a>, <a href="{{ site.baseurl }}/omero/organize/">organize</a>, <a href="{{ site.baseurl }}/omero/analyze/">analyze</a> and <a href="{{ site.baseurl }}/omero/organize/">share</a> your data from anywhere you
                         have internet access. Work with your images from a
                         desktop app(Windows, Mac or Linux), from the web or
                         from 3rd party software. Over 140 image file formats

--- a/omero/index.html
+++ b/omero/index.html
@@ -10,7 +10,7 @@ usergroup: omero
                     <p class="hero-subheader small-12">
                         From the microscope to <a href="{{ site.baseurl }}/omero/publish/">publication</a>,
                         OMERO handles all your images in a secure central
-                        repository. You can <a href="{{ site.baseurl }}/omero/view/">view</a>, <a href="{{ site.baseurl }}/omero/organize/">organize</a>, <a href="{{ site.baseurl }}/omero/analyze/">analyze</a> and <a href-"{ site.baseurl }}/omero/organize/">share</a> your data from anywhere you
+                        repository. You can <a href="{{ site.baseurl }}/omero/view/">view</a>, <a href="{{ site.baseurl }}/omero/organize/">organize</a>, <a href="{{ site.baseurl }}/omero/analyze/">analyze</a> and <a href-"{{ site.baseurl }}/omero/organize/">share</a> your data from anywhere you
                         have internet access. Work with your images from a
                         desktop app(Windows, Mac or Linux), from the web or
                         from 3rd party software. Over 140 image file formats

--- a/omero/institution/index.html
+++ b/omero/institution/index.html
@@ -13,7 +13,19 @@ usergroup: institutions
         <div class="row">
             <img class="medium-3 medium-offset-1 columns" alt="OMERO for Institutions" src="{{ site.baseurl }}/img/icons/user-groups_institutions.svg">
             <div class="medium-7 end columns">
-                <p>With OMERO, all the image data from your facility can be securely stored and managed, using group permissions and user roles to allow controlled access tailored to your institution. From private repositories for sensitive data to hosting public data for your website and latest publications, the permissions model is designed to meet the range of researchers’ needs. OMERO is tried and tested in hundreds of institutions world-wide, with extensive installation and configuration documentation for system administrators and community support via dedicated mailing lists and forums.</p>
+                <p>
+                    With OMERO, all the image data from your facility can be
+                    securely stored and managed, using group permissions and
+                    user roles to allow controlled access tailored to your
+                    institution. From private repositories for sensitive data
+                    to hosting public data for your website and latest <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/publication.html" target="blank">publications</a>,
+                    the permissions model is designed to meet the range of
+                    researchers’ needs. OMERO is tried and tested in hundreds
+                    of institutions world-wide, with extensive installation
+                    and configuration documentation for system administrators
+                    and community support via dedicated mailing lists and
+                    forums.
+                </p>
                 <p>We keep the community updated on any <a href="{{ site.baseurl }}/security/">security vulnerabilities</a> through our <a href="{{ site.baseurl }}/security/advisories">advisories</a> page.</p>
                 <p>Our commercial partners <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a> also offer tailored installations and support packages if needed.</p>
             </div>

--- a/omero/institution/index.html
+++ b/omero/institution/index.html
@@ -18,7 +18,7 @@ usergroup: institutions
                     securely stored and managed, using group permissions and
                     user roles to allow controlled access tailored to your
                     institution. From private repositories for sensitive data
-                    to hosting public data for your website and latest <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/publication.html" target="blank">publications</a>,
+                    to hosting public data for your website and latest <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/public.html" target="blank">publications</a>,
                     the permissions model is designed to meet the range of
                     researchers’ needs. OMERO is tried and tested in hundreds
                     of institutions world-wide, with extensive installation

--- a/omero/publish/index.html
+++ b/omero/publish/index.html
@@ -39,7 +39,6 @@ usergroup: omero
                     the need to log in.</p>
                 <a class="button hollow tiny" href="http://help.openmicroscopy.org/publish.html#public" target="_blank">View user guide</a>
                 <a class="button hollow tiny" href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/public.html" target="_blank">View administrator guide</a>
-                <a class="button hollow tiny" href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/publication.html" target="_blank">Complete workflow for data publication</a>
             </div>
             <div class="omero-feature-container tall-content column text-center">
                 <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_public-repo.svg">

--- a/omero/publish/index.html
+++ b/omero/publish/index.html
@@ -23,6 +23,7 @@ usergroup: omero
                 <h4>Create figures</h4>
                 <p>Create figures out-of-the-box or use OMERO.figure, an optional app, to fully customize your figure design.</p>
                 <a class="button hollow tiny" href="http://help.openmicroscopy.org/figure.html" target="_blank">View user guide</a>
+                <a class="button hollow tiny" href="https://www.youtube.com/watch?v=XF-ADVS7RNk" target="_blank">View Figure movie</a>
             </div>
             <div class="omero-feature-container tall-content column text-center">
                 <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_create-movies.svg">
@@ -38,6 +39,7 @@ usergroup: omero
                     the need to log in.</p>
                 <a class="button hollow tiny" href="http://help.openmicroscopy.org/publish.html#public" target="_blank">View user guide</a>
                 <a class="button hollow tiny" href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/public.html" target="_blank">View administrator guide</a>
+                <a class="button hollow tiny" href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/publication.html" target="_blank">Complete workflow for data publication</a>
             </div>
             <div class="omero-feature-container tall-content column text-center">
                 <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_public-repo.svg">

--- a/omero/scientists/index.html
+++ b/omero/scientists/index.html
@@ -13,7 +13,7 @@ usergroup: scientists
         <div class="row">
             <img class="medium-3 medium-offset-2 columns" alt="OMERO for Scientists" src="{{ site.baseurl }}/img/icons/user-groups_scientists.svg">
             <div class="medium-5 end columns">
-                <p>OMERO handles all your images using a secure central repository, from the microscope to publication.</p>
+                <p>OMERO handles all your images using a secure central repository, from the microscope to <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/publication.html" target="blank">publication</a>.</p>
                 <p>Using the power of Bio-Formats, OMERO supports over 140 image file formats, including all major microscope formats.</p>
             </div>
         </div>

--- a/omero/scientists/index.html
+++ b/omero/scientists/index.html
@@ -13,7 +13,7 @@ usergroup: scientists
         <div class="row">
             <img class="medium-3 medium-offset-2 columns" alt="OMERO for Scientists" src="{{ site.baseurl }}/img/icons/user-groups_scientists.svg">
             <div class="medium-5 end columns">
-                <p>OMERO handles all your images using a secure central repository, from the microscope to <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/publication.html" target="blank">publication</a>.</p>
+                <p>OMERO handles all your images using a secure central repository, from the microscope to <a href="{{ site.baseurl }}/omero/publish/">publication</a>.</p>
                 <p>Using the power of Bio-Formats, OMERO supports over 140 image file formats, including all major microscope formats.</p>
             </div>
         </div>

--- a/products/index.html
+++ b/products/index.html
@@ -16,7 +16,7 @@ title: Products
                 <h5>Handles your images in a central repo from microscope to publication</h5>
                 <p>
                     You can <a href="{{ site.baseurl }}/omero/view/">view</a>, <a href="{{ site.baseurl }}/omero/organize/">organize</a>, <a href="{{ site.baseurl }}/omero/analyze/">analyze</a>
-                    and <a href-"{{ site.baseurl }}/omero/organize/">share</a> 
+                    and <a href="{{ site.baseurl }}/omero/organize/">share</a> 
                     your data from anywhere you have internet
                     access. Work with your images
                     from a desktop app (Windows, Mac or Linux), from the web

--- a/products/index.html
+++ b/products/index.html
@@ -15,10 +15,12 @@ title: Products
                 <h3><img src="{{ site.baseurl }}/img/logos/omero.svg" alt="OMERO logo" class="section-title-img-logo" /></h3>                
                 <h5>Handles your images in a central repo from microscope to publication</h5>
                 <p>
-                    You can view, organize, analyze and share your data from
-                    anywhere you have internet access. Work with your images
+                    You can <a href="{{ site.baseurl }}/omero/view/">view</a>, <a href="{{ site.baseurl }}/omero/organize/">organize</a>, <a href="{{ site.baseurl }}/omero/analyze/">analyze</a>
+                    and <a href-"{ site.baseurl }}/omero/organize/">share</a> 
+                    your data from anywhere you have internet
+                    access. Work with your images
                     from a desktop app (Windows, Mac or Linux), from the web
-                    or from 3rd party software. <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/publication.html" target="blank">Publish</a>
+                    or from 3rd party software. <a href="{{ site.baseurl }}/omero/publish/">Publish</a>
                     your data direct from your server for reproducible
                     science.
                 </p>

--- a/products/index.html
+++ b/products/index.html
@@ -16,7 +16,7 @@ title: Products
                 <h5>Handles your images in a central repo from microscope to publication</h5>
                 <p>
                     You can <a href="{{ site.baseurl }}/omero/view/">view</a>, <a href="{{ site.baseurl }}/omero/organize/">organize</a>, <a href="{{ site.baseurl }}/omero/analyze/">analyze</a>
-                    and <a href-"{ site.baseurl }}/omero/organize/">share</a> 
+                    and <a href-"{{ site.baseurl }}/omero/organize/">share</a> 
                     your data from anywhere you have internet
                     access. Work with your images
                     from a desktop app (Windows, Mac or Linux), from the web

--- a/products/index.html
+++ b/products/index.html
@@ -14,7 +14,14 @@ title: Products
             <div class="medium-4 columns">
                 <h3><img src="{{ site.baseurl }}/img/logos/omero.svg" alt="OMERO logo" class="section-title-img-logo" /></h3>                
                 <h5>Handles your images in a central repo from microscope to publication</h5>
-                <p>You can view, organize, analyze and share your data from anywhere you have internet access. Work with your images from a desktop app (Windows, Mac or Linux), from the web or from 3rd party software.</p>
+                <p>
+                    You can view, organize, analyze and share your data from
+                    anywhere you have internet access. Work with your images
+                    from a desktop app (Windows, Mac or Linux), from the web
+                    or from 3rd party software. <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/publication.html" target="blank">Publish</a>
+                    your data direct from your server for reproducible
+                    science.
+                </p>
                 <a href="{{ site.baseurl }}/omero/" class="button small">Learn More</a>
             </div>
             <hr class="whitespace show-for-small-only">


### PR DESCRIPTION
See https://trello.com/c/gRkjWMSv/595-publication-workflow

This adds links to the new publication workflow page added in https://github.com/openmicroscopy/ome-documentation/pull/1815 - NOTE that this link won't work until 5.4.2 is released

Also added a Figure movie link I noticed was missing