### PR TITLE
OMERO 5.4.2 release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,8 +13,8 @@ bf:
  version: 5.7.3
 
 omero:
- version: 5.4.1
- build: b75
+ version: 5.4.2
+ build: b76
 
 omecommoncpp:
   version: 5.5.0

--- a/_posts/2018-01-23-omero-5-4-2.md
+++ b/_posts/2018-01-23-omero-5-4-2.md
@@ -7,13 +7,15 @@ Today we are releasing OMERO 5.4.2, a bug-fix release.
 
 Improvements include:
 
-* added documentation on a complete workflow for publishing data from
-  OMERO.server
-* added references to the new OMERO pyramid format documentation (within the
-  OME Data Model and File Formats documentation)
+* added documentation on a complete workflow for
+  [publishing data from OMERO.server](https://docs.openmicroscopy.org/latest/omero/sysadmins/public.html)
+* added references to the new
+  [OMERO pyramid format documentation](https://docs.openmicroscopy.org/latest/ome-model/omero-pyramid/index.html)
+  (within the OME Data Model and File Formats documentation)
 * faster loading of thumbnails for large Plates after a recent regression
 * made projecting images belonging to another user only possible for users
   with the required permissions to save the new images
+* improved the public user experience for password-less access
 * updated SwingX library version used by OMERO.insight to stop insight-ij
   plugin crashing in Fiji
 * CLI updates:
@@ -36,11 +38,14 @@ Developer updates include:
 * added methods for updating OMERO.tables
 * Java Gateway fixes for sessions and rendering
 * fixed retrieval of Plate thumbnail URLs
-* improved 'Editing OMERO.web' documentation
+* improved [Editing OMERO.web documentation](https://docs.openmicroscopy.org/latest/omero/developers/Web/EditingOmeroWeb.html)
 * improved Slice documentation for API deprecations
+* added instructions to
+  [documentation for OMERO.cli extensions](https://docs.openmicroscopy.org/latest/omero/developers/cli/extending.html)
+  on how to create CLI plugins that are ``pip`` installable
 * substantial effort to make third-party repositories easily testable;
   see [omero-test-infra](https://github.com/openmicroscopy/omero-test-infra)
   for more information
 
 This release also upgrades the version of Bio-Formats that OMERO uses to
-5.7.3.
+[5.7.3](https://docs.openmicroscopy.org/bio-formats/5.7.3/about/whats-new.html).

--- a/_posts/2018-01-23-omero-5-4-2.md
+++ b/_posts/2018-01-23-omero-5-4-2.md
@@ -27,21 +27,20 @@ Sysadmin changes include:
 * added warning about the need to regenerate your NGINX config for every
   upgrade
 * fixed documentation bug affecting OMERO-version-specific guidance
-* fixed OMERO.tables startup race condition
-* server performance improvements
+* improved OMERO.tables startup stability
+* server performance improvements and reduction in ERROR logging
 
 Developer updates include:
 
-* various testing improvements including refactoring and build system
-  changes, designed to permit integration tests in downstream projects and
-  testing of external CLI plugins (see [this PR on GitHub](https://github.com/openmicroscopy/openmicroscopy/pull/5616)
-  for further details)
+* extended Python and Java examples to include Map Annotations and histograms
 * added methods for updating OMERO.tables
 * Java Gateway fixes for sessions and rendering
-* extended Python and Java examples to include Map Annotations and histograms
+* fixed retrieval of Plate thumbnail URLs
 * improved 'Editing OMERO.web' documentation
 * improved Slice documentation for API deprecations
-* fixed retrieval of Plate thumbnail URLs
+* substantial effort to make third-party repositories easily testable;
+  see [omero-test-infra](https://github.com/openmicroscopy/omero-test-infra)
+  for more information
 
 This release also upgrades the version of Bio-Formats that OMERO uses to
 5.7.3.

--- a/_posts/2018-01-23-omero-5-4-2.md
+++ b/_posts/2018-01-23-omero-5-4-2.md
@@ -1,0 +1,47 @@
+---
+layout: post
+title: Release of OMERO 5.4.2
+intro-blurb: The OME team is pleased to announce the release of OMERO 5.4.2.
+---
+Today we are releasing OMERO 5.4.2, a bug-fix release.
+
+Improvements include:
+
+* added documentation on a complete workflow for publishing data from
+  OMERO.server
+* added references to the new OMERO pyramid format documentation (within the
+  OME Data Model and File Formats documentation)
+* faster loading of thumbnails for large Plates after a recent regression
+* made projecting images belonging to another user only possible for users
+  with the required permissions to save the new images
+* updated SwingX library version used by OMERO.insight to stop insight-ij
+  plugin crashing in Fiji
+* CLI updates:
+  * ``import --target`` into a container without the necessary permissions 
+    now fails before file upload starts and more transparently
+  * ``admin mail`` timeout is now configurable via ``--wait``
+  * added ``admin log`` command for inserting statements to the server log
+
+Sysadmin changes include:
+
+* added warning about the need to regenerate your NGINX config for every
+  upgrade
+* fixed documentation bug affecting OMERO-version-specific guidance
+* fixed OMERO.tables startup race condition
+* server performance improvements
+
+Developer updates include:
+
+* various testing improvements including refactoring and build system
+  changes, designed to permit integration tests in downstream projects and
+  testing of external CLI plugins (see [this PR on GitHub](https://github.com/openmicroscopy/openmicroscopy/pull/5616)
+  for further details)
+* added methods for updating OMERO.tables
+* Java Gateway fixes for sessions and rendering
+* extended Python and Java examples to include Map Annotations and histograms
+* improved 'Editing OMERO.web' documentation
+* improved Slice documentation for API deprecations
+* fixed retrieval of Plate thumbnail URLs
+
+This release also upgrades the version of Bio-Formats that OMERO uses to
+5.7.3.

--- a/omero/downloads/index.html
+++ b/omero/downloads/index.html
@@ -5,7 +5,7 @@ title: OMERO Downloads
         <div class="callout large primary" id="bg-image-omero">
             <div class="row column text-center">
                 <h1>OMERO {{ site.omero.version }} Downloads</h1>
-                <a href="{{ site.baseurl }}/2017/11/23/omero-5-4-1.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
+                <a href="{{ site.baseurl }}/2018/01/23/omero-5-4-2.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
                 <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/" target="_blank" class="hero-link">Read the Docs</a>
             </div>
         </div>
@@ -16,7 +16,7 @@ title: OMERO Downloads
             <h3 class="text-center">OMERO clients</h3>
             <hr>
             <div class="column">
-                <p>A standard OMERO user just needs to download the client package with the same major version as their institutional server (e.g., 5.2.0 clients will connect to 5.2.5 servers but not to 5.3.0 servers). Full instructions for installation are on the <a href="http://help.openmicroscopy.org/">help site</a>.</p>
+                <p>A standard OMERO user just needs to download the client package with the same major version as their institutional server (e.g., 5.3.0 clients will connect to 5.3.5 servers but not to 5.4.0 servers). Full instructions for installation are on the <a href="http://help.openmicroscopy.org/">help site</a>.</p>
                 <p>If you do not have an institutional server, you can <a href="http://qa.openmicroscopy.org.uk/registry/demo_account/">apply for an account on our demo server</a>.</p>
             </div>
             <div class="small-12 medium-4 columns">


### PR DESCRIPTION
See https://trello.com/c/SmHVM8nS/41-open-pr-against-wwwopenmicroscopyorg

Content for release announcement is copied from current state of https://github.com/openmicroscopy/openmicroscopy/pull/5623 and will need updating as that isn't finalized yet.