### PR TITLE
Add Figure releases to announcements 

### DIFF
--- a/_posts/2014-10-07-figure-1-0-0.md
+++ b/_posts/2014-10-07-figure-1-0-0.md
@@ -1,0 +1,49 @@
+---
+layout: post
+title: Release of OMERO.figure 1.0.0
+intro-blurb: The OME team is pleased to announce the release of OMERO.figure 1.0.0.
+---
+
+We are pleased to announce release of OMERO.figure 1.0.0.
+This release adds support for maximum-intensity Z-projection, as well as
+a number of other features and minor bug fixes.
+
+We have decided to remove the beta flag from OMERO.figure with this release,
+since it has been in use on our production OMERO
+server since its first release in March of this year.
+During that time, there have only been minor bug reports and the file format has remained
+very stable.
+
+Maximum-Intensity projection:
+
+  - For Z-stack images, you can click a button (below the channel buttons) to turn on Z-projection.
+    The range of Z-indices can then be chosen using a 2-handled Z-slider.
+  - Initially, the Z-range is only 5 slices and is centered on the current Z-index.
+    This allows you include objects just above and below the current position in the projection,
+    without losing your place in the Z-stack.
+  - If you want a projection of the entire Z-stack, you can simply drag the sliders to
+    the full range.
+
+Increment Z and T indices:
+
+  - Small arrow buttons at the ends of the Z and T sliders now allow you to increment the Z or T index of
+    all the selected panels by 1 at a time.
+  - This is particularly useful if you want to 'play' through a
+    movie of several selected panels at once. 
+
+Other Features:
+
+  - Exported PDF figures now contain the url of the source OMERO.figure file so that you can always return
+    to the original figure.
+  - When you go to open a figure (File > Open), only figures owned by you are initially displayed in the list. You can
+    find files belonging to collaborators in your OMERO groups by using the 'Owner' drop-down chooser.
+
+
+Bug Fixes:
+
+  - Editing of timestamp labels previously caused all selected labels to show the same text. This
+    has now been fixed.
+  - Exported PDFs are now named according to the figure name, instead of a timestamp-based name.
+
+
+Grab the release from the OMERO.figure [1.0.0 download page](https://downloads.openmicroscopy.org/figure/1.0.0/).

--- a/_posts/2014-10-07-figure-1-0-0.md
+++ b/_posts/2014-10-07-figure-1-0-0.md
@@ -4,7 +4,7 @@ title: Release of OMERO.figure 1.0.0
 intro-blurb: The OME team is pleased to announce the release of OMERO.figure 1.0.0.
 ---
 
-We are pleased to announce release of OMERO.figure 1.0.0.
+We are pleased to announce the release of OMERO.figure 1.0.0.
 This release adds support for maximum-intensity Z-projection, as well as
 a number of other features and minor bug fixes.
 

--- a/_posts/2014-10-07-figure-1-0-0.md
+++ b/_posts/2014-10-07-figure-1-0-0.md
@@ -8,6 +8,10 @@ We are pleased to announce the release of OMERO.figure 1.0.0.
 This release adds support for maximum-intensity Z-projection, as well as
 a number of other features and minor bug fixes.
 
+Watch a demonstration of the release below:
+
+<iframe width="640" height="360" src="//www.youtube.com/embed/P0MMKtIKdFY?rel=0" frameborder="0" allowfullscreen></iframe>
+
 We have decided to remove the beta flag from OMERO.figure with this release,
 since it has been in use on our production OMERO
 server since its first release in March of this year.

--- a/_posts/2015-04-02-figure-1-0-1.md
+++ b/_posts/2015-04-02-figure-1-0-1.md
@@ -1,0 +1,13 @@
+---
+layout: post
+title: Release of OMERO.figure 1.0.1
+intro-blurb: The OME team is pleased to announce the release of OMERO.figure 1.0.1.
+---
+This release allows OMERO.figure to be used with the latest 5.1.0 OMERO release.
+This release adds no new features or other bug fixes to OMERO.figure.
+
+However, a major release of OMERO.figure with several new features and bug fixes
+should be available in 2 or 3 weeks.
+
+Grab the release from the OMERO.figure [1.1.1 download page](https://downloads.openmicroscopy.org/figure/1.0.1/).
+

--- a/_posts/2015-04-02-figure-1-0-1.md
+++ b/_posts/2015-04-02-figure-1-0-1.md
@@ -9,5 +9,5 @@ This release adds no new features or other bug fixes to OMERO.figure.
 However, a major release of OMERO.figure with several new features and bug fixes
 should be available in 2 or 3 weeks.
 
-Grab the release from the OMERO.figure [1.1.1 download page](https://downloads.openmicroscopy.org/figure/1.0.1/).
+Grab the release from the OMERO.figure [1.0.1 download page](https://downloads.openmicroscopy.org/figure/1.0.1/).
 

--- a/_posts/2015-04-20-figure-1-1-0.md
+++ b/_posts/2015-04-20-figure-1-1-0.md
@@ -1,0 +1,72 @@
+---
+layout: post
+title: Release of OMERO.figure 1.1.0
+intro-blurb: The OME team is pleased to announce the release of OMERO.figure 1.1.0.
+---
+
+We are pleased to announce release of OMERO.figure 1.1.0.
+This release adds a number of features to the editing and export
+of figures.
+
+Multiple page figures:
+
+  - Under File > Page Setup you can choose up to 10 pages for the figure.
+  - Pages are laid out in a grid on the canvas and image panels can be dragged across the canvas onto the chosen page.
+  - Export will generate a multi-page PDF document or multiple TIFF images.
+
+Crop to region or ROI:
+
+  - A crop button beside the panel zoom slider launches a crop dialog.
+  - The crop region can be manually chosen by dragging to select an area of the displayed image.
+  - Alternatively, existing Rectangular ROIs on the image will be loaded from OMERO and can be picked as a crop region.
+
+Set dpi of panel images:
+
+  - On the 'Info' tab, you can set a minimum resolution for image panels when they are embedded
+    within the PDF figure on export. For example, 300 dpi is required by many journals.
+  - The Info tab will then display the 'current' dpi in the figure alongside the export dpi.
+  - When the figure is exported as PDF, the resolution of these panels will be boosted if it is
+    less than the chosen export dpi.
+  - Additional pixels will be created in the image and the data resampled using a bicubic filter. 
+
+Export of figures as TIFFs:
+
+  - You can now choose to export the figure as a TIFF image at 300 dpi.
+  - This matches the submission format for many journals and allows easy embedding in presentations.
+  - Images are resampled using a bicubic filter to match the final figure dpi.
+  - Multi-page figures will be exported as multiple TIFFs in a zip file.
+  - A PDF info page is also included if your export is in a zip.
+
+Export of panel images alongside figure:
+
+  - An additional export option allows the constituant images within a figure to be exported alongside
+    the figure as TIFFs.
+  - For each image panel, the full sized TIFF of the image is exported, as well as the cropped and rotated TIFF
+    that is embedded within the PDF or TIFF figure.
+  - If images are resampled to increase their dpi, they will be saved before and after resampling.
+  - This provides greater clarity as to the processing steps used in generating the figure and the TIFF images
+    could also be used for creating figures in other applications.
+
+Figure legend:
+
+  - Legends can be added to figures and will be included in the info PDF page when the figure is exported.
+  - You can use Markdown syntax to add simple formatting, such as bold and italics. Other formatting is
+    supported in the web view, but may not be displayed properly in the exported PDF info page.
+
+Other features:
+
+  - When multiple panels are selected, they can be automatically resized to "Align their Magnification" such
+    that features appear the same size in all panels.
+  - Labels can be added to Scalebars to indicate their length.
+  - A color picker allows any color to be chosen for image channels and labels.
+  - Units support: If used with OMERO 5.1, the pixel size units in imported images will be used for scale bar labels.
+  - Unicode support: Figures can now contain special characters.
+  - Figure export errors are now handled with an error button which displays the error in a new browser tab. 
+
+Bug fixes:
+
+  - Fix label & scalebar colors in PDF figure export
+
+
+Grab the release from the OMERO.figure [1.1.0 download page](https://downloads.openmicroscopy.org/figure/1.1.0/).
+

--- a/_posts/2015-04-20-figure-1-1-0.md
+++ b/_posts/2015-04-20-figure-1-1-0.md
@@ -4,7 +4,7 @@ title: Release of OMERO.figure 1.1.0
 intro-blurb: The OME team is pleased to announce the release of OMERO.figure 1.1.0.
 ---
 
-We are pleased to announce release of OMERO.figure 1.1.0.
+We are pleased to announce the release of OMERO.figure 1.1.0.
 This release adds a number of features to the editing and export
 of figures.
 

--- a/_posts/2015-04-20-figure-1-1-0.md
+++ b/_posts/2015-04-20-figure-1-1-0.md
@@ -8,6 +8,10 @@ We are pleased to announce the release of OMERO.figure 1.1.0.
 This release adds a number of features to the editing and export
 of figures.
 
+Watch a demonstration of these new features or read their description below:
+
+<iframe width="640" height="360" src="//www.youtube.com/embed/rJxxC3HeDmY?rel=0" frameborder="0" allowfullscreen></iframe>
+
 Multiple page figures:
 
   - Under File > Page Setup you can choose up to 10 pages for the figure.

--- a/_posts/2015-05-05-figure-1-1-1.md
+++ b/_posts/2015-05-05-figure-1-1-1.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: Release of OMERO.figure 1.1.1
+intro-blurb: The OME team is pleased to announce the release of OMERO.figure 1.1.1.
+---
+
+We are pleased to announce release of OMERO.figure 1.1.1 which
+is a point release that contains a small number of bug fixes and
+minor feature improvements.
+
+Bug Fixes:
+
+ - Fixes a bug with exporting a figure before saving it
+ - Fixes a bug with layout of newly-added big images
+
+Other Changes:
+
+ - Figure legend can now be accessed under menu: 'File' > 'Add Figure Legend'
+ - Add a README.txt file to zip files when exporting figure with panels as separate images
+ - Crop dialog is initially populated with the current crop region
+ - Slight increase in scalebar thickness to improve visibility
+
+
+Grab the release from the OMERO.figure [1.1.1 download page](https://downloads.openmicroscopy.org/figure/1.1.1/).

--- a/_posts/2015-05-05-figure-1-1-1.md
+++ b/_posts/2015-05-05-figure-1-1-1.md
@@ -4,7 +4,7 @@ title: Release of OMERO.figure 1.1.1
 intro-blurb: The OME team is pleased to announce the release of OMERO.figure 1.1.1.
 ---
 
-We are pleased to announce release of OMERO.figure 1.1.1 which
+We are pleased to announce the release of OMERO.figure 1.1.1 which
 is a point release that contains a small number of bug fixes and
 minor feature improvements.
 

--- a/_posts/2015-11-24-figure-1-2-0.md
+++ b/_posts/2015-11-24-figure-1-2-0.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title: Release of OMERO.figure 1.2.0
+intro-blurb: The OME team is pleased to announce the release of OMERO.figure 1.2.0.
+---
+
+We are pleased to announce the release of OMERO.figure 1.2.0. This release introduces support for illustrative ROIs on figure panels. ROIs drawn in OMERO.figure cannot yet be saved as new ROIs on the OMERO server and it is not yet possible to load ROIs from OMERO to use in OMERO.figure.
+
+- ROIs can be drawn on individual panels
+- Currently supports rectangle, line, arrow and ellipse
+- ROIs can be copied and pasted between panels
+- Rectangles can be pasted as a crop region on another panel
+
+Known Issues:
+
+- The ROI viewer for drawing and editing ROIs does not support rotated image
+  panels. Therefore, rotated panels are displayed without rotation while
+  adding ROIs in the ROI viewer
+- Rectangle ROIs cannot be rotated. Therefore, crop regions from rotated
+  images will lose their rotation when pasted to create ROI rectangles
+- ROIs extending outside of panels are not cropped to the panel when exported
+  to PDF
+
+Grab the release from the OMERO.figure [1.2.0 download page](https://downloads.openmicroscopy.org/figure/1.2.0/).
+

--- a/_posts/2015-11-24-figure-1-2-0.md
+++ b/_posts/2015-11-24-figure-1-2-0.md
@@ -11,6 +11,10 @@ We are pleased to announce the release of OMERO.figure 1.2.0. This release intro
 - ROIs can be copied and pasted between panels
 - Rectangles can be pasted as a crop region on another panel
 
+Watch a demonstration of the new ROI features and workflows below:
+
+<iframe width="640" height="360" src="//www.youtube.com/embed/0rphBmermAc?rel=0" frameborder="0" allowfullscreen></iframe>
+
 Known Issues:
 
 - The ROI viewer for drawing and editing ROIs does not support rotated image

--- a/_posts/2016-04-18-figure-1-2-1.md
+++ b/_posts/2016-04-18-figure-1-2-1.md
@@ -1,0 +1,16 @@
+---
+layout: post
+title: Release of OMERO.figure 1.2.1
+intro-blurb: The OME team is pleased to announce the release of OMERO.figure 1.2.1.
+---
+
+We are pleased to announce the release of OMERO.figure 1.2.1 which
+is a point release that contains a small number of bug fixes and
+minor feature improvements:
+
+- Faster listing of files in File > Open dialog
+- Improved filtering of listed files by name
+- Fixed a bug in rotating labels when exporting as TIFF
+- Fixed pixel sizes for images with custom pixel size units (not microns) 
+
+Grab the release from the OMERO.figure [1.2.1 download page](https://downloads.openmicroscopy.org/figure/1.2.1/).

--- a/_posts/2016-10-26-figure-2-0-0.md
+++ b/_posts/2016-10-26-figure-2-0-0.md
@@ -5,7 +5,7 @@ intro-blurb: The OME team is pleased to announce the release of OMERO.figure 2.0
 ---
 
 We are pleased to announce the release of OMERO.figure 2.0.0. This release
-features a complete re-organization of the code and the repository moving to
+features a complete reorganization of the code and the repository moving to
 the OME organization on GitHub.
 
 The OMERO.figure app is now available to install from

--- a/_posts/2016-10-26-figure-2-0-0.md
+++ b/_posts/2016-10-26-figure-2-0-0.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: Release of OMERO.figure 2.0.0
+intro-blurb: The OME team is pleased to announce the release of OMERO.figure 2.0.0.
+---
+
+We are pleased to announce the release of OMERO.figure 2.0.0. This release
+features a complete re-organization of the code and the repository moving to
+the OME organization on GitHub.
+
+The OMERO.figure app is now available to install from
+[PyPI](https://pypi.python.org/pypi/omero-figure).


### PR DESCRIPTION
Copies the Figure release announcements that previously only lived on figure.openmicroscopy.org across to the Announcements section of the website