### PR TITLE
Change OMERO feature section heading

### DIFF
--- a/_layouts/omero-features.html
+++ b/_layouts/omero-features.html
@@ -3,7 +3,7 @@
         {% include navbar-sub-omero.html %}
         
         <header class="header" id="bg-image-omero">            
-            <h1 class="headline">{{page.feature}} with OMERO</h1>
+            <h1 class="headline">Key Features of OMERO</h1>
             <div class="row show-for-small-only" style="height: 120px;"></div>           
             <ul class="header-subnav">
                 <li><a href="{{ site.baseurl }}/omero/features/">NEW</a></li>


### PR DESCRIPTION
@will-moore suggested this change on https://github.com/openmicroscopy/ome-documentation/pull/1841 I'm not sure it is necessary because we have the highlighted 'Features' menu item but opened a PR anyway to see what the balance of opinion is - happy to make the change if others think that landing on the 'new' section is confusing.