### PR TITLE
Rename 2018 user meeting

### DIFF
--- a/_posts/2018-02-09-user-meeting-2018.md
+++ b/_posts/2018-02-09-user-meeting-2018.md
@@ -1,11 +1,11 @@
 ---
 layout: post
-title: OME Users Meeting 2018 announced
-intro-blurb: The OME team is pleased to announce that the OME Users Meeting will be held May 30th - June 1st 2018 in Dundee
+title: 2018 OME Annual Users Meeting announced
+intro-blurb: The OME team is pleased to announce that the 2018 OME Annual Users Meeting will be held May 30th - June 1st 2018 in Dundee
 ---
 
-We are pleased to announce that the 13th Annual OME Users Meeting will be held
-May 30th - June 1st 2018 in Dundee.
+We are pleased to announce that the 2018 OME Annual Users Meeting will be
+held May 30th - June 1st 2018 in Dundee.
 
 We are working on the [program]({{site.baseurl}}/events/13th-annual-users-meeting-2018.html) and
 aim to release this in the next few weeks. We'll also post

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -1,8 +1,8 @@
 ---
 layout: news-events
 filename: events
-title: 13th Annual Users Meeting 2018
-main-blurb: The 13th Annual OME Users Meeting will be held at the University of Dundee from May 30th to June 1st 2018.
+title: 2018 OME Annual Users Meeting
+main-blurb: The 2018 OME Annual Users Meeting will be held at the University of Dundee from May 30th to June 1st 2018.
 ---          
                 
         <!-- begin Events -->

--- a/events/index.html
+++ b/events/index.html
@@ -11,8 +11,8 @@ main-blurb: Meet the OME team in person
 
             <div class="small-12 medium-8 medium-offset-2 columns">
                 <h6><i class="fa fa-calendar"></i> May 30 - June 1, 2018</h6>
-                <h2><a href="{{ site.baseurl }}/events/13th-annual-users-meeting-2018.html">13th Annual Users Meeting 2018</a></h2>
-                <p class="card-caption">The 13th Annual OME Users Meeting will be held at the University of Dundee from May 30th to June 1st 2018.</p>
+                <h2><a href="{{ site.baseurl }}/events/13th-annual-users-meeting-2018.html">2018 OME Annual Users Meeting</a></h2>
+                <p class="card-caption">The 2018 OME Annual Users Meeting will be held at the University of Dundee from May 30th to June 1st 2018.</p>
             </div>
             <hr class="medium-8">
             


### PR DESCRIPTION
June informs me that we aren't using '13th Annual' this year and the event should be called '2018 OME  Annual Users Meeting instead.