### PR TITLE
Add page title for features section

### DIFF
--- a/omero/developers/docs.html
+++ b/omero/developers/docs.html
@@ -1,6 +1,6 @@
 ---
 layout: omero-usergroup-devs
-title: Documentation
+title: OMERO for Developers
 usergroup: developers
 --- 
 

--- a/omero/developers/getting-started.html
+++ b/omero/developers/getting-started.html
@@ -1,6 +1,6 @@
 ---
 layout: omero-usergroup-devs
-title: Getting Started
+title: OMERO for Developers
 usergroup: developers
 ---     
 

--- a/omero/features/analyze/index.html
+++ b/omero/features/analyze/index.html
@@ -1,5 +1,6 @@
 ---
 layout: omero-features
+title: OMERO Features
 feature: Analyze
 usergroup: omero
 redirect_from:

--- a/omero/features/export/index.html
+++ b/omero/features/export/index.html
@@ -1,5 +1,6 @@
 ---
 layout: omero-features
+title: OMERO Features
 feature: Export
 usergroup: omero
 redirect_from:

--- a/omero/features/import/index.html
+++ b/omero/features/import/index.html
@@ -1,5 +1,6 @@
 ---
 layout: omero-features
+title: OMERO Features
 feature: Import
 usergroup: omero
 redirect_from:

--- a/omero/features/index.html
+++ b/omero/features/index.html
@@ -1,5 +1,6 @@
 ---
 layout: omero-features
+title: OMERO Features
 feature: NEW
 usergroup: omero
 redirect_from:

--- a/omero/features/learning/index.html
+++ b/omero/features/learning/index.html
@@ -1,5 +1,6 @@
 ---
 layout: omero-features
+title: OMERO Features
 feature: Teach
 usergroup: omero
 redirect_from:

--- a/omero/features/organize/index.html
+++ b/omero/features/organize/index.html
@@ -1,5 +1,6 @@
 ---
 layout: omero-features
+title: OMERO Features
 feature: Organize
 usergroup: omero
 redirect_from:

--- a/omero/features/publish/index.html
+++ b/omero/features/publish/index.html
@@ -1,5 +1,6 @@
 ---
 layout: omero-features
+title: OMERO Features
 feature: Publish
 usergroup: omero
 redirect_from:

--- a/omero/features/utility/index.html
+++ b/omero/features/utility/index.html
@@ -1,5 +1,6 @@
 ---
 layout: omero-features
+title: OMERO Features
 feature: Administrate
 usergroup: omero
 redirect_from:

--- a/omero/features/view/index.html
+++ b/omero/features/view/index.html
@@ -1,5 +1,6 @@
 ---
 layout: omero-features
+title: OMERO Features
 feature: View
 usergroup: omero
 redirect_from:

--- a/omero/scientists/docs.html
+++ b/omero/scientists/docs.html
@@ -1,6 +1,6 @@
 ---
 layout: omero-usergroup-sci
-title: Documentation
+title: OMERO for Scientists
 usergroup: scientists
 --- 
         

--- a/omero/scientists/getting-started.html
+++ b/omero/scientists/getting-started.html
@@ -1,6 +1,6 @@
 ---
 layout: omero-usergroup-sci
-title: Getting Started
+title: OMERO for Scientists
 usergroup: scientists
 ---     
 


### PR DESCRIPTION
See https://trello.com/c/cSY3Ftr4/146-odd-page-name - I'd forgotten to add page titles for this section.

At the moment this PR adds "OMERO Features" to all the subpages but in the scientists and devs sections, there are different titles for the different tabs (e.g. 'Getting Started') so the alternative is to add individual titles - "New with OMERO, "Import with OMERO" etc. Happy to change to that strategy if preferred.