### PR TITLE
Remove link redirected to legacy for old meetings

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -47,10 +47,3 @@ main-blurb: Meet the OME team in person
         </div>
         <!-- end Events -->
         <hr class="whitespace">
-        <div class="row">
-            <div class="small-12 medium-8 medium-offset-2">
-                <p class="callout primary">We are in the process of moving content to this new site at present. Details of earlier meetings are still available <a href="https://www.openmicroscopy.org/site/community/minutes/meetings">here</a>.</p>
-            </div>
-        </div>       
-        <hr class="invisible">
-        


### PR DESCRIPTION
As discussed at today's web meeting, this removes the link which is being redirected to legacy for the old meeting content