### PR TITLE
Older users meetings

### DIFF
--- a/events/11th-annual-users-meeting-2016.html
+++ b/events/11th-annual-users-meeting-2016.html
@@ -172,7 +172,7 @@ main-blurb: The 11th Annual OME Users Meeting was held at the University of Dund
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 3</span> - Working with Bio-Formats (developer-aimed session)</li>
-                    <li><a href-"https://downloads.openmicroscopy.org/presentations/2016/Users-Meeting/Workshops/Introduction-to-Bio-Formats/#/" target="_blank">Introduction to working with Bio-Formats</a> ( <i class="fa fa-file-video-o"></i><a href="https://downloads.openmicroscopy.org/presentations/2016/Users-Meeting/Workshops/Introduction-to-Bio-Formats.mp4" target="_blank"> Movie version</a>)</li>
+                    <li><a href="https://downloads.openmicroscopy.org/presentations/2016/Users-Meeting/Workshops/Introduction-to-Bio-Formats/#/" target="_blank">Introduction to working with Bio-Formats</a> ( <i class="fa fa-file-video-o"></i><a href="https://downloads.openmicroscopy.org/presentations/2016/Users-Meeting/Workshops/Introduction-to-Bio-Formats.mp4" target="_blank"> Movie version</a>)</li>
                     <li><a href="https://downloads.openmicroscopy.org/presentations/2016/Users-Meeting/Workshops/OME-File-Formats/#/" target="_blank">OME File Formats</a> ( <i class="fa fa-file-video-o"></i><a href="https://downloads.openmicroscopy.org/presentations/2016/Users-Meeting/Workshops/OME-File-Formats.mp4" target="_blank"> Movie version</a>)</li>
                     <li>Breakout sessions on working with Bio-Formats in Java &amp; Matlab</li>
                     <li>Working with large datasets</li>

--- a/events/8th-annual-users-meeting-june-2013.html
+++ b/events/8th-annual-users-meeting-june-2013.html
@@ -1,0 +1,324 @@
+---
+layout: news-events
+filename: events
+title: 8th Annual Users Meeting 2013
+main-blurb: The 8th Annual OME Users Meeting was held at Institut Pasteur in Paris on June 24-25 2013.
+---          
+                
+        <!-- begin Events -->
+        <hr class="whitespace">
+        <div class="row">        
+            <div class="column">
+                <h2 class="event-day">Day 1 — Monday 24th June, 2013</h2>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">08:30 - 09:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Registration &amp; coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:00 - 09:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Welcome</h3>
+                <h4 class="event-speaker">Jason Swedlow &amp; Spencer Shorte</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:15 - 09:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Overview of OME/Update &amp; Bio-Formats &amp; OMERO</h3>
+                <h4 class="event-speaker">Jason Swedlow, University of Dundee</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:30 - 09:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">ImageJ &amp; OME</h3>
+                <h4 class="event-speaker">Kevin Eliceiri, University Wisconsin-Madison</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:45 - 10:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Tracking with OMERO</h3>
+                <h4 class="event-speaker">Sebastien Besson, Harvard Medical School</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:00 - 10:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Project Update - Goldberg Lab</h3>
+                <h4 class="event-speaker">Ilya Goldberg, NIA Baltimore</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:15 - 10:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OMERO.searcher</h3>
+                <h4 class="event-speaker">Ivan Cao-Berg, Carnegie Mellon University</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:30 - 11:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee &amp; Refreshments</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:00 - 11:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Fluorescence Lifetime Imaging (FLIM) &amp; OMERO</h3>
+                <h4 class="event-speaker">Ian Munro, Imperial College London</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:15 - 11:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Hierarchial Data, Tagging and Search</h3>
+                <h4 class="event-speaker">Douglas Russell, University of Oxford</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:30 - 11:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Leading a horse to water, but will it drink?</h3>
+                <h4 class="event-speaker">Julien Jourde, Institut Pasteur</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:45 - 12:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Extending OMERO to Support Non-image Data</h3>
+                <h4 class="event-speaker">Gianluigi Zanetti, CRS4, Sardinia</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:00 - 12:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OMERO &amp; Atlas Informatics</h3>
+                <h4 class="event-speaker">Bill Hill, MRC Edinburgh</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:15 - 13:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Question &amp; Answer Session</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">13:00 - 14:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Group Photo &amp; Lunch</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:00 - 14:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">The JCB DataViewer: Bringing New Dimensions to Published Image Data</h3>
+                <h4 class="event-speaker">Liz Williams, The Rockefeller University Press</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:30 - 15:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">The Knockout Mouse Project (KOMP): Phenotyping, and the Data Management Challenge</h3>
+                <h4 class="event-speaker">James Denegre, The Jackson Laboratory</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">15:00 - 15:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Automated image analysis using OMERO scripts</h3>
+                <h4 class="event-speaker">Alex Herbert, University of Sussex</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">15:30 - 16:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee &amp; Refreshments</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">16:00 - 16:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">The Original Data Repository and other OME/OMERO applications at the Stowers Institute</h3>
+                <h4 class="event-speaker">Winfried Wiegraebe, Stowers Institute</h4>
+            </div>
+        </div>
+        
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">16:30 - 17:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Towards open development of microscopy and image analysis applications with ZEN software and .czi file format by Carl Zeiss</h3>
+                <h4 class="event-speaker">Olaf Selchow &amp; Markus Neumann, Carl Zeiss Microscopy GmbH</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">17:00 - 17:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Question &amp; Answer Session, Summary and Close</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">17:45 - 19:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Drinks Reception &amp; Poster Session</h3>
+            </div>
+        </div>
+        
+        <hr class="whitespace">
+        <div class="row">        
+            <div class="column">
+                <h2 class="event-day">Day 2 — Tuesday 25th June, 2013</h2>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">08:30 - 09:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee &amp; Refreshments</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:00 - 09:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Welcome</h3>
+                <h4 class="event-speaker">Jason Swedlow, University of Dundee</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:15 - 10:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Workshops - Round 1</h3>
+                    <ul class="event-workshop">
+                        <li>Installing OMERO for Real - How to configure an installation for your institution, E.g. LDAP, File Systems etc.</li>
+                        <li>Demo of latest desktop and web clients / Permissions / Publishing data/ Usability</li>
+                        <li>OMERO.FS - What the FS changes mean for admins &amp; users</li>
+                        <li>Analysis with OMERO - Scripting, ImageJ, Matlab, Extending the web UI etc.</li>
+                    </ul>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:30 - 11:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee &amp; Refreshments</h3>
+            </div>
+        </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">11:15 - 12:45</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Workshops -  Round 2</h3>
+                    <ul class="event-workshop">
+                        <li>Installing OMERO for Real - How to configure an installation for your institution, E.g. LDAP, File Systems etc.</li>
+                        <li>Demo of latest desktop and web clients / Permissions / Publishing data/ Usability</li>
+                        <li>OMERO.FS - What the FS changes mean for admins &amp; users</li>
+                        <li>Analysis with OMERO - Scripting, ImageJ, Matlab, Extending the web UI etc.</li>
+                    </ul>              
+                </div>
+            </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">12:15 - 13:30</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Lunch</h3>
+                </div>
+            </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">13:30 - 14:45</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Workshops - Round 3</h3>
+                    <ul class="event-workshop">
+                        <li>Informal software demonstrations. Your chance to meet and discuss with OME Consortium Developers</li>
+                    </ul>
+                </div>
+            </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">14:45 - 15:15</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Coffee &amp; Refreshments</h3>
+                </div>
+            </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">15:15 - 16:30</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Workshops - Round 4</h3>
+                    <ul class="event-workshop">
+                        <li>Informal software demonstrations. Your chance to meet and discuss with OME Consortium Developers</li>
+                    </ul>
+                </div>
+            </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">16:30 - 17:00</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Summary &amp; Close</h3>
+                    <h4 class="event-speaker">Jason Swedlow, University of Dundee</h4>
+                </div>
+            </div>
+        <!-- end Events -->
+        <hr class="whitespace">

--- a/events/annual-users-meeting-june-2010.html
+++ b/events/annual-users-meeting-june-2010.html
@@ -143,6 +143,14 @@ main-blurb: The 2010 OME Annual Users Meeting was held at Institut Pasteur in Pa
                 <h3 class="event-title">Coffee &amp; Posters</h3>
             </div>
         </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">16:30 - 17:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Agenda for Day 2: Workshop Titles</h3>
+            </div>
+        </div>
         
         <hr class="whitespace">
         <div class="row">        

--- a/events/annual-users-meeting-june-2010.html
+++ b/events/annual-users-meeting-june-2010.html
@@ -1,0 +1,237 @@
+---
+layout: news-events
+filename: events
+title: 2010 OME Annual Users Meeting
+main-blurb: The 2010 OME Annual Users Meeting was held at Institut Pasteur in Paris on June 15-16 2010.
+---          
+                
+        <!-- begin Events -->
+        <hr class="whitespace">
+        <div class="row">        
+            <div class="column">
+                <h2 class="event-day">Day 1 — 15th June, 2010</h2>
+                <p class="event-day-description">
+                    "Goal — Summaries, Reviews, and Foundation for
+                    Discussions"
+                </p>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:00 - 09:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Registration &amp; coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:30 - 09:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Welcome</h3>
+                <h4 class="event-speaker">Spencer Shorte</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:45 - 11:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OME Status Update</h3>
+                <h4 class="event-speaker">OME Team (Jason Swedlow/Kevin Eliceiri)</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:00 - 11:20</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:20 - 11:40</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Integrating with OMERO: Extending
+                    Visualization &amp; Quantification to 3D</h3>
+                <h4 class="event-speaker">Jerome Avondo</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:40 - 12:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OMERO implementation in Imperial
+                    College London</h3>
+                <h4 class="event-speaker">Martin Spitaler</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:00 - 12:20</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OME and KNIME</h3>
+                <h4 class="event-speaker">Martin Horn, Konstanz</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:20 - 12:40</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Fiji Is Just ImageJ – an Open Source
+                    platform for biological image analysis</h3>
+                <h4 class="event-speaker">Pavel Tomancak</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:40 - 13:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Bio-Formats in C++ applications</h3>
+                <h4 class="event-speaker">Aaron Ponti</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">13:00 - 14:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Lunch</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:00 - 14:20</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Leica High Content Screening
+                    Automation and OME</h3>
+                <h4 class="event-speaker">Stefan Schek, Leica</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:20 - 14:40</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Columbus – High Content solution based
+                    on OMERO</h3>
+                <h4 class="event-speaker">Karsten Kottig, PerkinElmer</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:40 - 15:10</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OMERO and PSLID</h3>
+                <h4 class="event-speaker">Robert Murphy, CMU</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">15:10 - 16:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee &amp; Posters</h3>
+            </div>
+        </div>
+        
+        <hr class="whitespace">
+        <div class="row">        
+            <div class="column">
+                <h2 class="event-day">Day 2 — 16th June, 2010</h2>
+                <p class="event-day-description">
+                    "Goal — User and Developer Access to OME Technology"
+                </p>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:00 - 09:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Arrival</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:30 - 11:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Workshop Session 1</h3>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title"><span class="event-workshop-room">Discussion</span></li>
+                    <li>OMERO.fs</li>
+                </ul>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title"><span class="event-workshop-room">Training</span></li>
+                    <li>Using Bio-Formats - Matlab &amp; ImageJ</li>
+                </ul>         
+            </div>
+        </div>
+         <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">11:00 - 12:30</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Workshop Session 2</h3>
+                    <ul class="event-workshop">
+                        <li class="event-workshop-title"><span class="event-workshop-room">Discussion</span></li>
+                        <li>Scripting</li>
+                    </ul>
+                    <ul class="event-workshop">
+                        <li class="event-workshop-title"><span class="event-workshop-room">Training</span></li>
+                        <li>Using OMERO</li>
+                    </ul>         
+                </div>
+            </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:30 - 14:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Lunch &amp; Discussion</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">14:00 - 15:15</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Workshop Session 3</h3>
+                    <ul class="event-workshop">
+                        <li class="event-workshop-title"><span class="event-workshop-room">Discussion</span></li>
+                        <li>Actions for defining Standards</li>
+                    </ul>
+                    <ul class="event-workshop">
+                        <li class="event-workshop-title"><span class="event-workshop-room">Training</span></li>
+                        <li>Using Bio-Formats - Matlab &amp; ImageJ</li>
+                    </ul>         
+                </div>
+            </div>
+            <div class="event-row row">
+                    <div class="small-12 medium-2 columns">
+                        <h5 class="event-time">15:15 - 16:30</h5>
+                    </div>
+                    <div class="small-12 medium-10 columns">
+                        <h3 class="event-title">Workshop Session 4</h3>
+                        <ul class="event-workshop">
+                            <li class="event-workshop-title"><span class="event-workshop-room">Discussion</span></li>
+                            <li>Priorities for 2010</li>
+                        </ul>
+                        <ul class="event-workshop">
+                            <li class="event-workshop-title"><span class="event-workshop-room">Training</span></li>
+                            <li>Using OMERO</li>
+                        </ul>         
+                    </div>
+                </div>
+        <!-- end Events -->
+        <hr class="whitespace">

--- a/events/annual-users-meeting-june-2011.html
+++ b/events/annual-users-meeting-june-2011.html
@@ -79,7 +79,7 @@ main-blurb: The 2011 OME Annual Users Meeting was held at Institut Pasteur in Pa
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">OMERO and FUSE</h3>
-                <h4 class="event-speaker">ohannes Schindelin, MPI-CBG</h4>
+                <h4 class="event-speaker">Johannes Schindelin, MPI-CBG</h4>
             </div>
         </div>
         <div class="event-row row">

--- a/events/annual-users-meeting-june-2011.html
+++ b/events/annual-users-meeting-june-2011.html
@@ -1,0 +1,273 @@
+---
+layout: news-events
+filename: events
+title: 2011 OME Annual Users Meeting
+main-blurb: The 2011 OME Annual Users Meeting was held at Institut Pasteur in Paris on June 15-16 2011.
+---          
+                
+        <!-- begin Events -->
+        <hr class="whitespace">
+        <div class="row">        
+            <div class="column">
+                <h2 class="event-day">Day 1 — Wednesday 15th June, 2011</h2>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:00 - 09:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Registration &amp; coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:30 - 09:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Welcome &amp; Introduction</h3>
+                <h4 class="event-speaker">Spencer Shorte &amp; Jason Swedlow</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:45 - 11:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OME Status Update</h3>
+                <h4 class="event-speaker">OME Team</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:00 - 11:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:15 - 11:40</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OMERO at Imperial College London</h3>
+                <h4 class="event-speaker">Martin Spitaler, Imperial College</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:40 - 12:05</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OMEGA: viral particle tracking work- and dataflows for images stored in OMERO</h3>
+                <h4 class="event-speaker">Caterina Strambio De Castillia, Univ Geneva</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:05 - 12:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OMERO in Action at the John Innes Centre</h3>
+                <h4 class="event-speaker">Jerome Avondo, JIC</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:30 - 12:55</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OMERO and FUSE</h3>
+                <h4 class="event-speaker">ohannes Schindelin, MPI-CBG</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">13:00 - 14:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Lunch</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:00 - 14:25</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Using OMERO to drive large scale population studies</h3>
+                <h4 class="event-speaker">Gianluigi Zanetti, CRS4</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:25 - 14:50</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Population Selection based on Cellular Fingerprints</h3>
+                <h4 class="event-speaker">Martin Daffertshofer, PerkinElmer</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:50 - 15:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OMERO.searcher</h3>
+                <h4 class="event-speaker">BK Cho, CMU (via Skype)</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">15:15 - 15:40</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Processing Multi-View Selective Plane Illumination Microscopy Data</h3>
+                <h4 class="event-speaker">Stephan Preibisch, MPI-CBG</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">15:40 - 16:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">16:00 - 16:25</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">What’s in a picture? New tools to promote image integrity</h3>
+                <h4 class="event-speaker">Liz Williams, JCB</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">16:25 - 16:50</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OMERO: A resource for electron microscopy</h3>
+                <h4 class="event-speaker">Ingvar Lagerstedt, EBI</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">16:50 - 17:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OME Future— an update on OME and Glencoe Software</h3>
+                <h4 class="event-speaker">Jason Swedlow, Univ of Dundee</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">17:30 - 18:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Discussion, Ideas Board</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">18:30 - 20:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Buffet Dinner and Posters</h3>
+            </div>
+        </div>
+        
+        <hr class="whitespace">
+        <div class="row">        
+            <div class="column">
+                <h2 class="event-day">Day 2 — Thursday 16th June, 2011</h2>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:00 - 09:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Arrival &amp; coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:30 - 09:55</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">ImageJ2 and the ImageJdev Project</h3>
+                <h4 class="event-speaker">Kevin Eliceiri, Univ Wisconsin, Madison</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:55 - 10:20</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Icy: a new open-source community image processing software</h3>
+                <h4 class="event-speaker">Fabrice de Chaumont, Institut Pasteur</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:20 - 10:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">XuvTools</h3>
+                <h4 class="event-speaker">Mario Emmenlauer, Biozentrum</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:45 - 11:10</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Open Source Tools for Large Scale Visualization and Image Analysis: ITK, VTK and ParaView</h3>
+                <h4 class="event-speaker">Julien Jomier, Kitware</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:10 - 11:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:45 - 13:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Priorities from the Ideas Board</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">13:00 - 14:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Buffet Lunch</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:00 - 16:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">User &amp; Developer Taster Sessions, and Workshops</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">16:00 - 16:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Meeting Summary</h3>
+            </div>
+        </div>
+        
+        <!-- end Events -->
+        <hr class="whitespace">

--- a/events/annual-users-meeting-june-2012.html
+++ b/events/annual-users-meeting-june-2012.html
@@ -1,0 +1,279 @@
+---
+layout: news-events
+filename: events
+title: 2012 OME Annual Users Meeting
+main-blurb: The 2012 OME Annual Users Meeting was held at Institut Pasteur in Paris on June 18-19 2012.
+---          
+                
+        <!-- begin Events -->
+        <hr class="whitespace">
+        <div class="row">        
+            <div class="column">
+                <h2 class="event-day">Day 1 — Monday 18th June, 2012</h2>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">08:30 - 09:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Registration &amp; coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:00 - 09:10</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Welcome &amp; Introduction</h3>
+                <h4 class="event-speaker">Spencer Shorte, Institut Pasteur  &amp; Jason Swedlow, OME Dundee</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:10 - 09:35</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OME in Dundee</h3>
+                <h4 class="event-speaker">Emma Hill, Dundee</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:35 - 10:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">OMERO: Down Under</h3>
+                <h4 class="event-speaker">Kim Linton, Monash University</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:00 - 10:25</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Inspiring application of OMERO – a case study</h3>
+                <h4 class="event-speaker">Steve Rawsthorne, John Innes Centre</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:25 - 10:50</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Columbus for HCS and Secondary Analysis</h3>
+                <h4 class="event-speaker">Martin Daffertshofer, PerkinElmer</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:50 - 11:20</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:20 - 11:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">The JCB DataViewer: Bringing New Dimensions to Published Image Data</h3>
+                <h4 class="event-speaker">Liz Williams, JCB</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:45 - 12:10</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">ImageJ2 – ImageJ for the Next Generation of Biological Image Data</h3>
+                <h4 class="event-speaker">Kevin Eliceiri, Univ Wisconsin-Madison</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:10 - 12:35</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Using OMERO for yeast high throughput microscopy: from images to networks</h3>
+                <h4 class="event-speaker">Anatole Chessel, Gurdon Institute, Univ of Cambridge</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:35 - 12:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Group Picture</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:45 - 14:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Lunch</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:15 - 14:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Satellite Overview</h3>
+                <h4 class="event-speaker">Jason Swedlow, OME Dundee</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:15 - 14:40</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">What Can Woolz Bring To OME?</h3>
+                <h4 class="event-speaker">Bill Hill, MRC-HGU</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:40 - 15:05</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">CellOrganizer, PatternUnmixer and OMERO</h3>
+                <h4 class="event-speaker">Bob Murphy, Carnegie Mellon University</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">15:05 - 15:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Icy–An Open-Source Community Image Processing Software</h3>
+                <h4 class="event-speaker">Jean-Christophe Olivo-Marin, Institut Pasteur</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">15:30 - 16:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">16:00 - 17:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Josh’s Annual Polling Priorities and Wishes</h3>
+                <h4 class="event-speaker">Josh Moore, OME &amp; Glencoe Software</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">17:30 - 19:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Poster Session with Wine &amp; Nibbles</h3>
+            </div>
+        </div>
+        
+        <hr class="whitespace">
+        <div class="row">        
+            <div class="column">
+                <h2 class="event-day">Day 2 — Tuesday 19th June, 2012</h2>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">08:30 - 09:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:00 - 09:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Introduction</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:15 - 10:45</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Workshop I</h3>
+                    <ul class="event-workshop">
+                        <li>Implementing OMERO</li>
+                        <li>Integrating with Insight</li>
+                        <li>Extending OMERO.web</li>
+                        <li>Integrating Bio-Formats</li>
+                        <li>OMERO Usability &amp; User feedback</li>
+                    </ul>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:45 - 11:15</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee</h3>
+            </div>
+        </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">11:15 - 12:45</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Workshop II</h3>
+                    <ul class="event-workshop">
+                        <li>Integrating with Insight</li>
+                        <li>Integrating Bio-Formats</li>
+                        <li>Writing scripts</li>
+                        <li>OMERO Usability &amp; User feedback</li>
+                    </ul>              
+                </div>
+            </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">12:45 - 14:00</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Lunch</h3>
+                </div>
+            </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">14:00 - 15:30</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Workshop III</h3>
+                    <ul class="event-workshop">
+                        <li>Extending OMERO.web</li>
+                        <li>Integrating Bio-Formats</li>
+                        <li>Integrating OME and ImageJ into KNIME for high-throughput image analysis </li>
+                        <li>OMERO Usability &amp; User feedback</li>
+                    </ul>
+                </div>
+            </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">15:30 - 16:00</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Coffee</h3>
+                </div>
+            </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">16:00 - 17:00</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Feedback &amp; Wrap-up</h3>
+                </div>
+            </div>
+        <!-- end Events -->
+        <hr class="whitespace">

--- a/events/index.html
+++ b/events/index.html
@@ -45,6 +45,13 @@ main-blurb: Meet the OME team in person
             <hr class="medium-8">
 
             <div class="small-12 medium-8 medium-offset-2 columns">
+                <h6><i class="fa fa-calendar"></i> June 18-19, 2012</h6>
+                <h2><a href="{{ site.baseurl }}/events/annual-users-meeting-june-2012.html">2012 OME Annual Users Meeting</a></h2>
+                <p class="card-caption">The 2012 OME Annual Users Meeting was held at Institut Pasteur in Paris from June 18th to 19th 2011.</p>
+            </div>
+            <hr class="medium-8">
+
+            <div class="small-12 medium-8 medium-offset-2 columns">
                 <h6><i class="fa fa-calendar"></i> June 15-16, 2011</h6>
                 <h2><a href="{{ site.baseurl }}/events/annual-users-meeting-june-2011.html">2011 OME Annual Users Meeting</a></h2>
                 <p class="card-caption">The 2011 OME Annual Users Meeting was held at Institut Pasteur in Paris from June 15th to 16th 2011.</p>

--- a/events/index.html
+++ b/events/index.html
@@ -45,6 +45,13 @@ main-blurb: Meet the OME team in person
             <hr class="medium-8">
 
             <div class="small-12 medium-8 medium-offset-2 columns">
+                <h6><i class="fa fa-calendar"></i> June 15-16, 2011</h6>
+                <h2><a href="{{ site.baseurl }}/events/annual-users-meeting-june-2011.html">2011 OME Annual Users Meeting</a></h2>
+                <p class="card-caption">The 2011 OME Annual Users Meeting was held at Institut Pasteur in Paris from June 15th to 16th 2011.</p>
+            </div>
+            <hr class="medium-8">
+            
+            <div class="small-12 medium-8 medium-offset-2 columns">
                 <h6><i class="fa fa-calendar"></i> June 15-16, 2010</h6>
                 <h2><a href="{{ site.baseurl }}/events/annual-users-meeting-june-2010.html">2010 OME Annual Users Meeting</a></h2>
                 <p class="card-caption">The 2010 OME Annual Users Meeting was held at Institut Pasteur in Paris from June 15th to 16th 2010.</p>

--- a/events/index.html
+++ b/events/index.html
@@ -44,6 +44,13 @@ main-blurb: Meet the OME team in person
             </div>
             <hr class="medium-8">
 
+            <div class="small-12 medium-8 medium-offset-2 columns">
+                <h6><i class="fa fa-calendar"></i> June 15-16, 2010</h6>
+                <h2><a href="{{ site.baseurl }}/events/annual-users-meeting-june-2010.html">2010 OME Annual Users Meeting</a></h2>
+                <p class="card-caption">The 2010 OME Annual Users Meeting was held at Institut Pasteur in Paris from June 15th to 16th 2010.</p>
+            </div>
+            <hr class="medium-8">
+
         </div>
         <!-- end Events -->
         <hr class="whitespace">

--- a/events/index.html
+++ b/events/index.html
@@ -45,6 +45,13 @@ main-blurb: Meet the OME team in person
             <hr class="medium-8">
 
             <div class="small-12 medium-8 medium-offset-2 columns">
+                <h6><i class="fa fa-calendar"></i> June 24-25, 2013</h6>
+                <h2><a href="{{ site.baseurl }}/events/8th-annual-users-meeting-june-2013.html">8th Annual Users Meeting 2013</a></h2>
+                <p class="card-caption">The 8th Annual OME Users Meeting was held at Institut Pasteur in Paris from June 24th to 25th 2013.</p>
+            </div>
+            <hr class="medium-8">
+
+            <div class="small-12 medium-8 medium-offset-2 columns">
                 <h6><i class="fa fa-calendar"></i> June 18-19, 2012</h6>
                 <h2><a href="{{ site.baseurl }}/events/annual-users-meeting-june-2012.html">2012 OME Annual Users Meeting</a></h2>
                 <p class="card-caption">The 2012 OME Annual Users Meeting was held at Institut Pasteur in Paris from June 18th to 19th 2011.</p>


### PR DESCRIPTION
Adds the user meeting programmes for 2010-2013 - content from https://www-legacy.openmicroscopy.org/site/community/minutes/meetings

No links to presentations as yet - @joshmoore 's mirroring has downloaded all the pdfs from plone, I suggest we make zip bundles for each year and upload to http://downloads.openmicroscopy.org/presentations/ maybe `/user-meetings-archive`? and then I'll add one link per page at the top of the programme