### PR TITLE
Remove URLs to registration URL for 2018 Users meeting

### DIFF
--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -10,14 +10,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         <hr class="whitespace">
         <div class="row">        
             <div class="column">
-                <h2 class="event-day">Registration is now OPEN!</h2>
-                <p class="event-day-description">
-                    <a href="https://www.buyat.dundee.ac.uk/conferences-and-events/school-of-life-sciences/ome-annual-users-meeting/2018-ome-annual-users-meeting" target="_blank">Register now</a> to book your place.
-                    Registration is open until <B>30th April 2018</B> and is
-                    £115 per person, including lunches, refreshments, dinners
-                    on 30th and 31st May, and airport transfers by bus if
-                    required.
-                </p>
+                <h2 class="event-day">Registration is now CLOSED!</h2>
             </div>
         </div>
         

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@ title: Home
                 <div class="small-12 columns bg-image-text-container">
                     <h1 class="hero-main-header small-12">OME Annual Users Meeting</h1>
                     <p class="small-10 small-offset-1 medium-6 medium-offset-3">Join us May 30th to June 1st in Dundee!</p>
-                    <br>
                 </div>
             </div>
         </header>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ title: Home
             <div class="row homepage text-center">
                 <div class="small-12 columns bg-image-text-container">
                     <h1 class="hero-main-header small-12">OME Annual Users Meeting</h1>
-                    <p class="small-10 small-offset-1 medium-6 medium-offset-3">Join us May 30th to June 1st in Dundee!</p>
+                    <p class="small-10 small-offset-1 medium-6 medium-offset-3">May 30th to June 1st in Dundee!</p>
                 </div>
             </div>
         </header>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,6 @@ title: Home
                     <h1 class="hero-main-header small-12">OME Annual Users Meeting</h1>
                     <p class="small-10 small-offset-1 medium-6 medium-offset-3">Join us May 30th to June 1st in Dundee!</p>
                     <br>
-                    <a href="https://www.buyat.dundee.ac.uk/conferences-and-events/school-of-life-sciences/ome-annual-users-meeting/2018-ome-annual-users-meeting" class="large button sites-button btn-red">Register Now</a>
-                    <p class="event-highlight"><a href="{{ site.baseurl }}/events/13th-annual-users-meeting-2018.html" class="hero-link">See the schedule</a><p>
                 </div>
             </div>
         </header>


### PR DESCRIPTION
The only leftover place is the post from February 23th which we could edit or leave in place.