### PR TITLE
Add programme for Day 2 of 2018 Users meeting

### DIFF
--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -102,7 +102,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                 <h5 class="event-time">11:00 - 11:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
-                <h3 class="event-title">Coffee</h3>
+                <h3 class="event-title">Tea/coffee</h3>
             </div>
         </div>
         <div class="event-row row">
@@ -173,7 +173,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                 <h5 class="event-time">15:45 - 16:15</h5>
             </div>
             <div class="small-12 medium-10 columns">
-                <h3 class="event-title">Coffee</h3>
+                <h3 class="event-title">Tea/coffee</h3>
             </div>
         </div>
         <div class="event-row row">

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -208,6 +208,14 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
+                <h5 class="event-time">08:45 - 09:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Arrival with tea/coffee and introduction</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
                 <h5 class="event-time">09:00 - 10:00</h5>
             </div>
             <div class="small-12 medium-10 columns">
@@ -237,7 +245,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                 <h5 class="event-time">11:00-11:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
-                <h3 class="event-title">Coffee</h3>
+                <h3 class="event-title">Tea/coffee</h3>
             </div>
         </div>
         <div class="event-row row">
@@ -312,7 +320,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                 <h5 class="event-time">15:30-16:00</h5>
             </div>
             <div class="small-12 medium-10 columns">
-                <h3 class="event-title">Coffee</h3>
+                <h3 class="event-title">Tea/coffee</h3>
             </div>
         </div>
         <div class="event-row row">
@@ -326,6 +334,14 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                     <span class="event-workshop-room">Room 1</span> - 
                     OMERO and KNIME</li>
                 </ul>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">17:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Wine tasting and buffet dinner</h3>
             </div>
         </div>
         </div>

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -271,7 +271,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">11:00-11:30</h5>
+                <h5 class="event-time">11:00 - 11:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Tea/coffee</h3>
@@ -279,7 +279,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">11:30-12:30</h5>
+                <h5 class="event-time">11:30 - 12:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Workshop</h3>
@@ -296,7 +296,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">12:30-13:30</h5>
+                <h5 class="event-time">12:30 - 13:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Lunch</h3>
@@ -304,7 +304,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">13:30-14:30</h5>
+                <h5 class="event-time">13:30 - 14:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Workshops</h3>
@@ -330,7 +330,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">14:30-15:30</h5>
+                <h5 class="event-time">14:30 - 15:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Workshops</h3>
@@ -358,7 +358,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">15:30-16:00</h5>
+                <h5 class="event-time">15:30 - 16:00</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Tea/coffee</h3>
@@ -366,7 +366,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">16:00-17:00</h5>
+                <h5 class="event-time">16:00 - 17:00</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Community workshops</h3>

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -205,6 +205,128 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                     Users that cover various aspects of using OME's tools.
                 </p>
             </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">09:00 - 10:00</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Metadata matters workshop (1/3)</h3>
+                    <ul class="event-workshop">
+                        <li class="event-workshop-title">
+                        <span class="event-workshop-room">Room 1</span> - 
+                        Import Data</li>
+                    </ul>
+                </div>
+            </div>
+            <div class="event-row row">
+                <div class="small-12 medium-2 columns">
+                    <h5 class="event-time">10:00 - 11:00</h5>
+                </div>
+                <div class="small-12 medium-10 columns">
+                    <h3 class="event-title">Metadata matters workshop (2/3)</h3>
+                    <ul class="event-workshop">
+                        <li class="event-workshop-title">
+                        <span class="event-workshop-room">Room 1</span> -
+                        Analyze raw data with OMERO</li>
+                    </ul>
+                </div>
+            </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:30-11:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:30-12:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Metadata matters workshop (3/3)</h3>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title">
+                    <span class="event-workshop-room">Room 1</span> -
+                    Handling metadata</li>
+                </ul>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">12:30-13:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Lunch</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">13:30-14:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Parallel workshops</h3>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title">
+                    <span class="event-workshop-room">Room 1</span> - 
+                    OMERO Ops</li>
+                </ul>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title">
+                    <span class="event-workshop-room">Room 2</span> - 
+                    General OMERO Introduction</li>
+                </ul>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title">
+                    <span class="event-workshop-room">Room 3</span> - 
+                    Hacking session</li>
+                </ul>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">14:30-15:30</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Parallel workshops</h3>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title">
+                    <span class="event-workshop-room">Room 1</span> - 
+                    OME New File Formats</li>
+                </ul>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title">
+                    <span class="event-workshop-room">Room 2</span> - 
+                    OMERO Microservices demonstration</li>
+                </ul>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title">
+                    <span class="event-workshop-room">Room 3</span> - 
+                    Hacking session</li>
+                </ul>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">15:30-16:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Coffee</h3>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">16:00-17:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Community workshops</h3>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title">
+                    <span class="event-workshop-room">Room 1</span> - 
+                    OMERO and KNIME</li>
+                </ul>
+            </div>
+        </div>
         </div>
         
         

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -265,7 +265,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                     <span class="event-workshop-room">Room 1</span> -
                     Raw Data analysis</li>
                     <li>Fiji manual and scripting workflow</li>
-                    <li>Analysis workflow server side using MERO.scripts and R notebook)</li>
+                    <li>Analysis workflow server side using OMERO.scripts</li>
                 </ul>
             </div>
         </div>

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -205,32 +205,33 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                     Users that cover various aspects of using OME's tools.
                 </p>
             </div>
-            <div class="event-row row">
-                <div class="small-12 medium-2 columns">
-                    <h5 class="event-time">09:00 - 10:00</h5>
-                </div>
-                <div class="small-12 medium-10 columns">
-                    <h3 class="event-title">Metadata matters workshop (1/3)</h3>
-                    <ul class="event-workshop">
-                        <li class="event-workshop-title">
-                        <span class="event-workshop-room">Room 1</span> - 
-                        Import Data</li>
-                    </ul>
-                </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:00 - 10:00</h5>
             </div>
-            <div class="event-row row">
-                <div class="small-12 medium-2 columns">
-                    <h5 class="event-time">10:00 - 11:00</h5>
-                </div>
-                <div class="small-12 medium-10 columns">
-                    <h3 class="event-title">Metadata matters workshop (2/3)</h3>
-                    <ul class="event-workshop">
-                        <li class="event-workshop-title">
-                        <span class="event-workshop-room">Room 1</span> -
-                        Analyze raw data with OMERO</li>
-                    </ul>
-                </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Metadata matters workshop (1/3)</h3>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title">
+                    <span class="event-workshop-room">Room 1</span> - 
+                    Import Data</li>
+                </ul>
             </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">10:00 - 11:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Metadata matters workshop (2/3)</h3>
+                <ul class="event-workshop">
+                    <li class="event-workshop-title">
+                    <span class="event-workshop-room">Room 1</span> -
+                    Analyze raw data with OMERO</li>
+                </ul>
+            </div>
+        </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
                 <h5 class="event-time">10:30-11:00</h5>

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -264,8 +264,8 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                     <li class="event-workshop-title">
                     <span class="event-workshop-room">Room 1</span> -
                     Raw Data analysis</li>
-                    <li>Fiji manual & scripting workflow</li>
-                    <li>Analysis workflow (OMERO.scripts and R notebook)</li>
+                    <li>Fiji manual and scripting workflow</li>
+                    <li>Analysis workflow server side using MERO.scripts and R notebook)</li>
                 </ul>
             </div>
         </div>
@@ -287,6 +287,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                     <li class="event-workshop-title">
                     <span class="event-workshop-room">Room 1</span> -
                     Handling metadata</li>
+                    <li>Plot OMERO.tables results using R</li>
                     <li>Add Map Annotations client-side</li>
                     <li>Search metadata using OMERO.mapr</li>
                     <li>Analyze metadata using OMERO.parade</li>

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -242,11 +242,15 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                 <h5 class="event-time">09:00 - 10:00</h5>
             </div>
             <div class="small-12 medium-10 columns">
-                <h3 class="event-title">Metadata matters workshop (1/3)</h3>
+                <h3 class="event-title">Workshop</h3>
                 <ul class="event-workshop">
                     <li class="event-workshop-title">
                     <span class="event-workshop-room">Room 1</span> - 
                     Import Data</li>
+                    <li>Desktop client import</li>
+                    <li>In-place import using OMERO.CLI</li>
+                    <li>Bulk import using OMERO.CLI</li>
+                    <li>Render data using OMERO.CLI</li>
                 </ul>
             </div>
         </div>
@@ -255,11 +259,13 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                 <h5 class="event-time">10:00 - 11:00</h5>
             </div>
             <div class="small-12 medium-10 columns">
-                <h3 class="event-title">Metadata matters workshop (2/3)</h3>
+                <h3 class="event-title">Workshop</h3>
                 <ul class="event-workshop">
                     <li class="event-workshop-title">
                     <span class="event-workshop-room">Room 1</span> -
-                    Analyze raw data with OMERO</li>
+                    Raw Data analysis</li>
+                    <li>Fiji manual & scripting workflow</li>
+                    <li>Analysis workflow (OMERO.scripts and R notebook)</li>
                 </ul>
             </div>
         </div>
@@ -276,11 +282,15 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                 <h5 class="event-time">11:30-12:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
-                <h3 class="event-title">Metadata matters workshop (3/3)</h3>
+                <h3 class="event-title">Workshop</h3>
                 <ul class="event-workshop">
                     <li class="event-workshop-title">
                     <span class="event-workshop-room">Room 1</span> -
                     Handling metadata</li>
+                    <li>Add Map Annotations client-side</li>
+                    <li>Search metadata using OMERO.mapr</li>
+                    <li>Analyze metadata using OMERO.parade</li>
+                    <li>Metadata using OMERO.figure</li>
                 </ul>
             </div>
         </div>
@@ -297,11 +307,14 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                 <h5 class="event-time">13:30-14:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
-                <h3 class="event-title">Parallel workshops</h3>
+                <h3 class="event-title">Workshops</h3>
                 <ul class="event-workshop">
                     <li class="event-workshop-title">
                     <span class="event-workshop-room">Room 1</span> - 
                     OMERO Ops</li>
+                    <li>Monitoring using shell scripts, cron jobs and check_mk</li>
+                    <li>Monitoring using Prometheus and Grafana</li>
+                    <li>Ansible deployment</li>
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title">
@@ -320,16 +333,21 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                 <h5 class="event-time">14:30-15:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
-                <h3 class="event-title">Parallel workshops</h3>
+                <h3 class="event-title">Workshops</h3>
                 <ul class="event-workshop">
                     <li class="event-workshop-title">
                     <span class="event-workshop-room">Room 1</span> - 
                     OME New File Formats</li>
+                    <li>OME-TIFF pyramidal support</li>
+                    <li>New binary vessels</li>
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title">
                     <span class="event-workshop-room">Room 2</span> - 
                     OMERO Microservices demonstration</li>
+                    <li>Purpose and implementation of microservices</li>
+                    <li>Example: omero-ms-mapr</li>
+                    <li>Deployment of microservices</li>
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title">

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -314,7 +314,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                     OMERO Ops</li>
                     <li>Monitoring using shell scripts, cron jobs and check_mk</li>
                     <li>Monitoring using Prometheus and Grafana</li>
-                    <li>Ansible deployment</li>
+                    <li>Discussion of other deployment concerns</li>
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title">

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -248,9 +248,9 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                     <span class="event-workshop-room">Room 1</span> - 
                     Import Data</li>
                     <li>Desktop client import</li>
-                    <li>In-place import using OMERO.CLI</li>
-                    <li>Bulk import using OMERO.CLI</li>
-                    <li>Render data using OMERO.CLI</li>
+                    <li>In-place import using OMERO.cli</li>
+                    <li>Bulk import using OMERO.cli</li>
+                    <li>Render data using OMERO.cli</li>
                 </ul>
             </div>
         </div>
@@ -265,7 +265,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                     <span class="event-workshop-room">Room 1</span> -
                     Raw Data analysis</li>
                     <li>Fiji manual and scripting workflow</li>
-                    <li>Analysis workflow server side using OMERO.scripts</li>
+                    <li>Analysis workflow server-side using OMERO.scripts</li>
                 </ul>
             </div>
         </div>

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -234,7 +234,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">10:30-11:00</h5>
+                <h5 class="event-time">11:00-11:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Coffee</h3>


### PR DESCRIPTION
Couple of initial decisions open for discussion in addition to the usual spelling/formatting review:

- I re-used the same CSS layout as the [previous Users meeting](https://www.openmicroscopy.org/events/12th-annual-users-meeting-2017.html)
- for the morning workshops, the `event-title` class is used to highlight the workshop theme
- the program only includes workshops titles for now. Bullet points can be added in a second step or once final
- the last workshop is expected to grow as we receive interest from the community