### PR TITLE
Day1 short talks final

### DIFF
--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -33,7 +33,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">09:00</h5>
+                <h5 class="event-time">09:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Opening and welcome remarks</h3>

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -33,6 +33,15 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
+                <h5 class="event-time">09:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">Opening and welcome remarks</h3>
+                <h4 class="event-speaker">Jason Swedlow, OME</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
                 <h5 class="event-time">09:30 - 09:45</h5>
             </div>
             <div class="small-12 medium-10 columns">
@@ -81,7 +90,16 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">10:45 - 11:15</h5>
+                <h5 class="event-time">10:45 - 11:00</h5>
+            </div>
+            <div class="small-12 medium-10 columns">
+                <h3 class="event-title">AutoTx Smart automatic background data transfer for Windows</h3>
+                <h4 class="event-speaker">Alison Walter, LOCI</h4>
+            </div>
+        </div>
+        <div class="event-row row">
+            <div class="small-12 medium-2 columns">
+                <h5 class="event-time">11:00 - 11:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Coffee</h3>
@@ -89,7 +107,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">11:15 - 12:30</h5>
+                <h5 class="event-time">11:30 - 12:45</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title"><a
@@ -99,7 +117,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">12:30 - 13:30</h5>
+                <h5 class="event-time">12:45 - 13:45</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Lunch</h3>
@@ -107,16 +125,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">13:30 - 13:40</h5>
-            </div>
-            <div class="small-12 medium-10 columns">
-                <h3 class="event-title">Welcome</h3>
-                <h4 class="event-speaker">Jason Swedlow, OME</h4>
-            </div>
-        </div>
-        <div class="event-row row">
-            <div class="small-12 medium-2 columns">
-                <h5 class="event-time">13:40 - 14:10</h5>
+                <h5 class="event-time">13:45 - 14:15</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">OME Project Summary and Progress</h3>
@@ -125,7 +134,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">14:10 - 14:40</h5>
+                <h5 class="event-time">14:15 - 14:45</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Image Data Integration and Publication at Scale: Update on the IDR</h3>
@@ -134,7 +143,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">14:40 - 15:10</h5>
+                <h5 class="event-time">14:45 - 15:15</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Update on OME File Formats</h3>
@@ -143,7 +152,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">15:10 - 15:25</h5>
+                <h5 class="event-time">15:15 - 15:30</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Tools for OME Training and Outreach</h3>
@@ -152,7 +161,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">15:25 - 15:40</h5>
+                <h5 class="event-time">15:30 - 15:45</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Tools for OMERO Users</h3>
@@ -161,7 +170,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">15:40 - 16:10</h5>
+                <h5 class="event-time">15:45 - 16:15</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Coffee</h3>
@@ -169,7 +178,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">16:10 - 16:40</h5>
+                <h5 class="event-time">16:15 - 16:45</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Glencoe Software Update</h3>
@@ -178,7 +187,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">16:40 - 17:15</h5>
+                <h5 class="event-time">16:45 - 17:20</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">Introducing a data-standard for fluorescence microscopy: increasing data quality and fidelity for biological measurements</h3>
@@ -187,7 +196,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
         </div>
         <div class="event-row row">
             <div class="small-12 medium-2 columns">
-                <h5 class="event-time">17:15 - 17:45</h5>
+                <h5 class="event-time">17:20 - 17:45</h5>
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">One-minute poster talks</h3>

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -234,36 +234,6 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
                 </p>
             </div>
         </div>
-        
-        <hr class="whitespace">
-            <div class="row">        
-                <div class="column">
-                    <h2 class="event-day">Deadlines for lightning talk titles and poster abstracts</h2>
-                    <p class="event-day-description">
-                        If you would like to present a lightning talk, please
-                        answer 'yes' during registration, send us a short
-                        title by <B>Tuesday 8th May</B> and prepare a maximum
-                        of five slides. Ideally the slides should be submitted
-                        in advance but they can be brought to the meeting on a
-                        portable memory stick.
-                    </p>
-                    <p class="event-day-description">
-                        Also during the registration process, you will also be
-                        asked if you would like to present a poster. If so, a
-                        one-page A4 poster abstract with a short title in Word
-                        or PDF format should be submitted to June Matthew by
-                        <B>Tuesday 8th May</B>. We ask that you prepare and
-                        bring one slide with a brief description of your
-                        poster to the meeting for a short 1 minute
-                        presentation before the poster session.
-                </div>
-            </div>
-        
-        <hr class="whitespace">
-            <div class="row">        
-                <div class="column">
-                    <h2 class="event-day">More details coming soon! Watch this space for speaker announcements.</h2>
-                </div>
-            </div>
+
         <!-- end Events -->
         <hr class="whitespace">

--- a/events/13th-annual-users-meeting-2018.html
+++ b/events/13th-annual-users-meeting-2018.html
@@ -94,7 +94,7 @@ main-blurb: The 2018 OME Annual Users Meeting will be held at the University of 
             </div>
             <div class="small-12 medium-10 columns">
                 <h3 class="event-title">AutoTx Smart automatic background data transfer for Windows</h3>
-                <h4 class="event-speaker">Alison Walter, LOCI</h4>
+                <h4 class="event-speaker">Niko Ehrenfeuchter, Biozentrum - University of Basel</h4>
             </div>
         </div>
         <div class="event-row row">


### PR DESCRIPTION
Discussed with June, this adds Niko's short talk to the schedule. Additional modifications are:
- Opening/Welcome slot from the afternoon is moved to the morning
- Lunch is moved by 15min
- All afternoon timeslots are moved by 5min. Start and end times (except for last speaker) are now all at :00, :15, :30 or :45.
- final sections about deadlines and upcoming programme are removed as the programme will be finalized by the end of the week