### PR TITLE
docker: Use branch name rather than "master"

### DIFF
--- a/_includes/docker-compose.yml
+++ b/_includes/docker-compose.yml
@@ -13,6 +13,6 @@ services:
       - CONFIG_omero_db_pass=postgres
       - ROOTPASS=omero
   web:
-    image: openmicroscopy/omero-web-standalone:master
+    image: openmicroscopy/omero-web-standalone:5.4
     ports:
       - 4080:4080


### PR DESCRIPTION
The automated master branch is not regularly tested
and should be removed once this change has been propagated
to the website.