### PR TITLE
Review citation page external links

### DIFF
--- a/citing-ome/index.html
+++ b/citing-ome/index.html
@@ -18,10 +18,16 @@ title: Citing OME
             <div class="small-12 medium-8 columns">
                 <p>The 2010 article outlining the importance of metadata and introducing the OME Compliant Specification:</p>
                 <p class="citation">Melissa Linkert, Curtis T. Rueden, Chris Allan, Jean-Marie Burel, Will Moore, Andrew Patterson, Brian Loranger, Josh Moore, Carlos Neves, Donald MacDonald, Aleksandra Tarkowska, Caitlin Sticco, Emma Hill, Mike Rossner, Kevin W. Eliceiri, and Jason R. Swedlow (2010) Metadata matters: access to image data in the real world. The Journal of Cell Biology 189(5), 777-782. doi: 10.1083/jcb.201004104</p>
-                <p><a class="pmid" href="http://www.ncbi.nlm.nih.gov/pubmed/20513764" target="_blank">20513764</a></p>
+                <p>DOI: <a href="https://doi.org/10.1083/jcb.201004104" target="_blank">10.1083/jcb.201004104</a>
+                PMID: <a href="https://www.ncbi.nlm.nih.gov/pubmed/20513764/" target="_blank">20513764</a>
+                PMCID: <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2878938/" target="_blank">PMC2878938</a>
+                </p>
                 <p>The original OME Data Model paper from 2005:</p>
                 <p class="citation">Goldberg, I., C. Allan, J.-M. Burel, D. Creager, A. Falconi, H. Hochheiser, J. Johnston, J. Mellen, P.K. Sorger, and J.R. Swedlow. (2005) The Open Microscopy Environment (OME) Data Model and XML File: Open Tools for Informatics and Quantitative Analysis in Biological Imaging. Genome Biol. 6:R47.</p>
-                <p><a class="pmid" href="http://www.ncbi.nlm.nih.gov/pubmed/15892875" target="_blank">15892875</a></p>
+                <p>DOI: <a href="https://doi.org/10.1186/gb-2005-6-5-r47" target="_blank">10.1186/gb-2005-6-5-r47</a>
+                PMID: <a class="pmid" href="https://www.ncbi.nlm.nih.gov/pubmed/15892875/" target="_blank">15892875</a>
+                PMCID: <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1175959/" target="_blank">PMC1175959</a>
+                </p>
             </div>            
         </div>      
         <!-- end citation-->
@@ -34,7 +40,10 @@ title: Citing OME
             </div>
             <div class="small-12 medium-8 columns">
                 <p class="citation">Melissa Linkert, Curtis T. Rueden, Chris Allan, Jean-Marie Burel, Will Moore, Andrew Patterson, Brian Loranger, Josh Moore, Carlos Neves, Donald MacDonald, Aleksandra Tarkowska, Caitlin Sticco, Emma Hill, Mike Rossner, Kevin W. Eliceiri, and Jason R. Swedlow (2010) Metadata matters: access to image data in the real world. The Journal of Cell Biology 189(5), 777-782. doi: 10.1083/jcb.201004104</p>
-                <p><a class="pmid" href="http://www.ncbi.nlm.nih.gov/pubmed/20513764" target="_blank">20513764</a></p>
+                <p>DOI: <a href="https://doi.org/10.1083/jcb.201004104" target="_blank">10.1083/jcb.201004104</a>
+                PMID: <a href="https://www.ncbi.nlm.nih.gov/pubmed/20513764" target="_blank">20513764</a>
+                PMCID: <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2878938/" target="_blank">PMC2878938</a>
+                </p>
             </div>            
         </div>      
         <!-- end citation-->
@@ -48,13 +57,19 @@ title: Citing OME
             <div class="small-12 medium-8 columns">
                 <p>The original OMERO paper from 2012:</p>
                 <p class="citation">Chris Allan, Jean-Marie Burel, Josh Moore, Colin Blackburn, Melissa Linkert, Scott Loynton, Donald MacDonald, William J Moore, Carlos Neves, Andrew Patterson, Michael Porter, Aleksandra Tarkowska, Brian Loranger, Jerome Avondo, Ingvar Lagerstedt, Luca Lianas, Simone Leo, Katherine Hands, Ron T Hay, Ardan Patwardhan, Christoph Best, Gerard J Kleywegt, Gianluigi Zanetti &amp; Jason R Swedlow (2012) OMERO: flexible, model-driven data management for experimental biology. Nature Methods 9, 245–253. Published: 28 February 2012</p>
-                <p><a class="pmid" href="http://www.ncbi.nlm.nih.gov/pubmed/22373911" target="_blank">22373911</a></p>
+                <p>DOI: <a href="https://doi.org/10.1038/nmeth.1896" target="_blank">10.1038/nmeth.1896</a>
+                PMID: <a href="https://www.ncbi.nlm.nih.gov/pubmed/22373911" target="_blank">22373911</a>
+                PMCID: <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3437820/" target="_blank">PMC3437820</a></p>
                 <p>OMERO for high content screening:</p>
                 <p class="citation">Simon Li, Sébastien Besson, Colin Blackburn, Mark Carroll, Richard K. Ferguson, Helen Flynn, Kenneth Gillen, Roger Leigh, Dominik Lindner, Melissa Linkert, William J. Moore, Balaji Ramalingam, Emil Rozbicki, Gabriella Rustici, Aleksandra Tarkowska, Petr Walczysko, Eleanor Williams, Chris Allan, Jean-Marie Burel, Josh Moore, Jason R. Swedlow (2016) Metadata management for high content screening in OMERO. Methods 96, 27-32. Published: 1 March 2016</p>
-                <p><a href="http://dx.doi.org/10.1016/j.ymeth.2015.10.006" target="_blank">doi:10.1016/j.ymeth.2015.10.006</a></p>
+                <p>DOI: <a href="https://doi.org/10.1016/j.ymeth.2015.10.006" target="_blank">10.1016/j.ymeth.2015.10.006</a>
+                PMID: <a class="pmid" href="https://www.ncbi.nlm.nih.gov/pubmed/26476368/" target="_blank">26476368</a>
+                PMCID: <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4773399/" target="_blank">PMC4773399</a></p>
                 <p>Publishing and sharing with OMERO:</p>
                 <p class="citation">Jean-Marie Burel, Sébastien Besson, Colin Blackburn, Mark Carroll, Richard K. Ferguson, Helen Flynn, Kenneth Gillen, Roger Leigh, Simon Li, Dominik Lindner, Melissa Linkert, William J. Moore, Balaji Ramalingam, Emil Rozbicki, Aleksandra Tarkowska, Petr Walczysko, Chris Allan, Josh Moore, Jason R. Swedlow (2015) Publishing and sharing multi-dimensional image data with OMERO. Mammalian Genome 26, 441-447. Published 30 July 2015</p>
-                <p><a href="http://dx.doi.org/10.1007/s00335-015-9587-6" target="_blank">doi:10.1007/s00335-015-9587-6</a></p>
+                <p>DOI: <a href="https://doi.org/10.1007/s00335-015-9587-6" target="_blank">10.1007/s00335-015-9587-6</a>
+                PMID: <a href="https://www.ncbi.nlm.nih.gov/pubmed/26223880/" target="_blank">26223880</a>
+                PMCID: <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4602067/" target="_blank">PMC4602067</a></p>
             </div>            
         </div>      
         <!-- end citation-->
@@ -67,7 +82,9 @@ title: Citing OME
             </div>
             <div class="small-12 medium-8 columns">
                 <p class="citation">Eleanor Williams, Josh Moore, Simon W. Li, Gabriella Rustici, Aleksandra Tarkowska, Anatole Chessel, Simone Leo, Bálint Antal, Richard K. Ferguson, Ugis Sarkans, Alvis Brazma, Rafael E. Carazo Salas, Jason R. Swedlow (2017) The Image Data Resource: A Bioimage Data Integration and Publication Platform. Nature Methods 14(8), 775-781. Published 19 June 2017</p>
-                <p><a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5536224/" target="_blank">PMCID: PMC5536224</a></p>
+                <p>DOI: <a href="https://doi.org/10.1038/nmeth.4326" target="_blank">10.1038/nmeth.4326</a>
+                PMID: <a href="https://www.ncbi.nlm.nih.gov/pubmed/28775673/" target="_blank">28775673</a>
+                PMCID: <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5536224/" target="_blank">PMC5536224</a></p>
             </div>            
         </div>
         <!-- end citation-->
@@ -80,7 +97,10 @@ title: Citing OME
             </div>
             <div class="small-12 medium-8 columns">
                 <p class="citation">Swedlow JR, Goldberg I, Brauner E, Sorger PK (2003) Informatics and quantitative analysis in biological imaging. Science 300(5616), 100-2. Published 4 April 2003</p>
-                <p><a href="https://www.ncbi.nlm.nih.gov/pubmed/12677061" target="_blank">PMID: 12677061</a></p>
+                <p>DOI: <a href="https://doi.org/10.1126/science.1082602" target="_blank">10.1126/science.1082602</a>
+                PMID: <a href="https://www.ncbi.nlm.nih.gov/pubmed/12677061/" target="_blank">12677061</a>
+                PMCID: <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5536224/" target="_blank">PMC5536224</a>
+                </p>
             </div>            
         </div>
         <!-- end citation-->


### PR DESCRIPTION
Unify the hyperlinks for all citations to point to the Publication DOI, the PubMed ID as well as the PMC ID

Noticed the inconsistencies in the page as well as the absence of the PMC hyperlinks while reviewing https://github.com/ome/bio-formats-documentation/pull/30. Since DOIs, PMID and PMCID are available for all our publications, there is no reason not to expose all this metadata.