### PR TITLE
Include a version/date string in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,8 @@
                     <div class="medium-4"><a href="{{ site.baseurl }}/index.html"><img class="footer-logo" src="{{ site.baseurl }}/img/logos/ome-main-nav.svg" alt="OME logo" /></a></div>
                     <p>&copy; 2005-{{ site.time | date: "%Y" }} University of Dundee &amp; Open Microscopy Environment. <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank">Creative Commons Attribution 4.0 International License</a></p>
                     <p>OME source code is available under the <a href="http://www.gnu.org/copyleft/gpl.html">GNU General public license</a> or more permissive open source licenses, or through commercial license from <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a>.</p>
-                    <p class="tiny-print">[ <a href="{{ site.baseurl }}/site-map/">Site Map</a> ]</p>
+                    <p class="tiny-print" style="float:left;">[ <a href="{{ site.baseurl }}/site-map/">Site Map</a> ]</p>
+                    <p class="tiny-print" style="float:right;">Version: {{ site.time | date: '%Y.%m.%d' }}</p>
                 </div>
                 <div class="medium-2 columns">
                     <h6>Learn About Us</h6>


### PR DESCRIPTION
The [new deployment process](https://github.com/openmicroscopy/www.openmicroscopy.org/pull/239) is so quick it'd be nice to have confirmation that the site was updated. This adds the build (tag) date to the footer.
<img width="507" alt="screen shot 2018-07-12 at 16 19 42" src="https://user-images.githubusercontent.com/1644105/42642746-72900368-85ef-11e8-890c-240f1ddc88c9.png">

Note that since this uses the build date and not the tag it's possible these will disagree, for example if you do a manual build, or if travis is delayed to the day after the tag