### PR TITLE
Include future-dated posts in build

### DIFF
--- a/_prod.yml
+++ b/_prod.yml
@@ -1,4 +1,2 @@
 baseurl: ''
 ga_token: 'UA-49953125-6'
-
-future: false


### PR DESCRIPTION
Whilst testing a related build from a separate private repo we discovered `future: false` inhibits the generation of future-dated posts. Since the [new deployment workflow decouples the build from the deployment](https://github.com/openmicroscopy/www.openmicroscopy.org/pull/239) this means you can't tag the repo and run the build ahead of time, it has to be done on the same day as the deployment. This PR therefore removes this flag.