### PR TITLE
training pages

### DIFF
--- a/_includes/navbar-main.html
+++ b/_includes/navbar-main.html
@@ -41,7 +41,12 @@
                             <li><a href="{{ site.baseurl }}/ome-files/">OME Files</a></li>
                         </ul>
                     </li>
-                    <li><a href="{{ site.baseurl }}/support/">Support</a></li>
+                    <li class="has-submenu"><a href="#">Support</a>
+                        <ul class="submenu menu vertical" data-submenu>
+                            <li><a href="{{ site.baseurl }}/support/">Users</a></li>
+                            <li><a href="{{ site.baseurl }}/training/">Training</a></li>
+                        </ul>
+                    </li>
                     <li><a href="{{ site.baseurl }}/docs/">Docs</a></li>
                     <li class="hide-for-small-only"><a href="{{ site.baseurl }}/explore/" class="button btn-indigo" style="color: #eceff1; margin-left: 10px;">Explore</a></li>
                     <li class="show-for-small-only"><a href="{{ site.baseurl }}/explore/">Explore</a></li>

--- a/_includes/navbar-main.html
+++ b/_includes/navbar-main.html
@@ -41,7 +41,7 @@
                             <li><a href="{{ site.baseurl }}/ome-files/">OME Files</a></li>
                         </ul>
                     </li>
-                    <li class="has-submenu"><a href="#">Support</a>
+                    <li class="has-submenu"><a href="{{ site.baseurl }}/support/">Support</a>
                         <ul class="submenu menu vertical" data-submenu>
                             <li><a href="{{ site.baseurl }}/support/">Users</a></li>
                             <li><a href="{{ site.baseurl }}/training/">Training</a></li>

--- a/_includes/navbar-main.html
+++ b/_includes/navbar-main.html
@@ -18,6 +18,7 @@
                             <li><a href="{{ site.baseurl }}/licensing/">Licensing</a></li>
                             <li><a href="{{ site.baseurl }}/citing-ome/">Citing OME</a></li>
                             <li><a href="{{ site.baseurl }}/artwork/">Artwork</a></li>
+                            <li><a href="{{ site.baseurl }}/training/">Training</a></li>
                         </ul>
                     </li>
                     <li class="has-submenu"><a href="{{ site.baseurl }}/news/">News</a>

--- a/_includes/navbar-main.html
+++ b/_includes/navbar-main.html
@@ -43,7 +43,6 @@
                     </li>
                     <li class="has-submenu"><a href="{{ site.baseurl }}/support/">Support</a>
                         <ul class="submenu menu vertical" data-submenu>
-                            <li><a href="{{ site.baseurl }}/support/">Users</a></li>
                             <li><a href="{{ site.baseurl }}/training/">Training</a></li>
                         </ul>
                     </li>

--- a/support/index.html
+++ b/support/index.html
@@ -86,6 +86,19 @@ title: Support
                     </div>
                 </div>
             </div>
+            <div class="small-12 medium-4 columns">
+                <div class="card card-support">
+                    <div class="card-section">
+                        <i class="border-red icon-red fa fa-graduation-cap fa-2x"></i>
+                        <h4>OME Training</h4>
+                        <p class="card-caption">Find or host an OMERO workshop or download workshop materials</p>
+                        <a href="{{ site.baseurl }}/training/" class="btn-blue button small">Training Page</a>
+                    </div>
+                </div>
+            </div>
+            <div class="small-12 medium-4 columns">
+                <!-- Placeholder to stop previous card floating right -->
+            </div>
         </div>
         <!-- end Resources-->
         

--- a/training/index.html
+++ b/training/index.html
@@ -64,7 +64,7 @@ title: OMERO Training
             <div class="small-12 medium-3 columns">
                 <div class="card card-support">
                     <div class="card-section">
-                        <i class="border-green icon-green fa fa-graduation-cap fa-2x"></i>
+                        <i class="border-red icon-red fa fa-graduation-cap fa-2x"></i>
                         <h4>Run a workshop</h4>
                         <p class="card-caption">Find information on how to run your own workshop.</p>
                         <a href="{{ site.baseurl }}/training/omero/" class="btn-blue button small">Workshop setup</a>

--- a/training/index.html
+++ b/training/index.html
@@ -1,8 +1,7 @@
 ---
 layout: default
 title: OMERO Training
----     
-        {% include navbar-sub-omero.html %}
+---
         
         <div class="callout large primary" id="bg-image-omero">
             <div class="row column text-center">

--- a/training/index.html
+++ b/training/index.html
@@ -37,7 +37,7 @@ title: OMERO Training
                     <div class="card-section">
                         <i class="border-red icon-red fa fa-envelope-o fa-2x"></i>
                         <h4>Contact us</h4>
-                        <p class="card-caption">Get in touch to discuss a workshop at your institution.</p>
+                        <p class="card-caption">Get in touch to discuss a workshop at your site.</p>
                         <a href="{{ site.baseurl }}/support/" class="btn-blue button small">Contact Us</a>
                     </div>
                 </div>

--- a/training/index.html
+++ b/training/index.html
@@ -24,7 +24,7 @@ title: OMERO Training
                 setup procedures used.
             </p>
             <p>
-                Our workshops range in length from a 1-hour overview of OMERO up to a full-day.
+                Our workshops range in length from a 1-hour overview of OMERO up to a full day.
                 For more detailed coverage, a 2-day workshop can be used to provide an introduction
                 to OMERO on one day and more advanced analysis, developer or sysadmin features
                 on the next.

--- a/training/index.html
+++ b/training/index.html
@@ -6,7 +6,7 @@ title: OMERO Training
         
         <div class="callout large primary" id="bg-image-omero">
             <div class="row column text-center">
-                <h1>OMERO Training</h1>
+                <h1>OME Training</h1>
                 <p>
                     OME wants to promote understanding of our products with practical
                     workshops in the community.

--- a/training/index.html
+++ b/training/index.html
@@ -8,8 +8,8 @@ title: OMERO Training
             <div class="row column text-center">
                 <h1>OME Training</h1>
                 <p>
-                    OME wants to promote understanding of our products with practical
-                    workshops in the community.
+                    To promote understanding of our products, regular practical workshops
+                    are organised in the community.
                 </p>
             </div>
         </div>

--- a/training/index.html
+++ b/training/index.html
@@ -23,6 +23,12 @@ title: OMERO Training
                 materials we develop are freely available along with the image data and
                 setup procedures used.
             </p>
+            <p>
+                Our workshops range in length from a 1-hour overview of OMERO up to a full-day.
+                For more detailed coverage, a 2-day workshop can be used to provide an introduction
+                to OMERO on one day and more advanced analysis, developer or sysadmin features
+                on the next.
+            </p>
         </div>
 
         <div class="row">

--- a/training/index.html
+++ b/training/index.html
@@ -1,0 +1,74 @@
+---
+layout: default
+title: OMERO Training
+---     
+        {% include navbar-sub-omero.html %}
+        
+        <div class="callout large primary" id="bg-image-omero">
+            <div class="row column text-center">
+                <h1>OMERO Training</h1>
+                <p>
+                    OME wants to promote understanding of our products with practical
+                    workshops in the community.
+                </p>
+            </div>
+        </div>
+        
+
+        <hr class="whitespace">
+
+        <div class="row column text-center">
+            <h2>General</h2>
+        </div>
+        <hr>
+        <div class="row column">
+            <p>
+                The OME team is keen to provide outreach workshops in the community to
+                demonstrate the features of our tools within imaging workflows. The training
+                materials we develop are freely available along with the image data and
+                setup procedures used.
+            </p>
+        </div>
+
+        <div class="row">
+            <div class="small-12 medium-3 columns">
+                <div class="card card-support">
+                    <div class="card-section">
+                        <i class="border-red icon-red fa fa-envelope-o fa-2x"></i>
+                        <h4>Contact us</h4>
+                        <p class="card-caption">Get in touch to discuss a workshop at your institution.</p>
+                        <a href="{{ site.baseurl }}/support/" class="btn-blue button small">Contact Us</a>
+                    </div>
+                </div>
+            </div>
+            <div class="small-12 medium-3 columns">
+                <div class="card card-support">
+                    <div class="card-section">
+                        <i class="border-green icon-green fa fa-calendar-o fa-2x"></i>
+                        <h4>Workshops</h4>
+                        <p class="card-caption">Check our events page for upcoming workshops.</p>
+                        <a href="{{ site.baseurl }}/events/" class="btn-blue button small">Events</a>
+                    </div>
+                </div>
+            </div>
+            <div class="small-12 medium-3 columns">
+                <div class="card card-support">
+                    <div class="card-section">
+                        <i class="border-blue icon-blue fa fa-file-alt fa-2x"></i>
+                        <h4>Materials</h4>
+                        <p class="card-caption">Browse training materials from recent workshops.</p>
+                        <a href="https://github.com/ome/training-repos/" target="_blank" class="btn-blue button small"></a>
+                    </div>
+                </div>
+            </div>
+            <div class="small-12 medium-3 columns">
+                <div class="card card-support">
+                    <div class="card-section">
+                        <i class="border-green icon-green fa fa-graduation-cap fa-2x"></i>
+                        <h4>Run a workshop</h4>
+                        <p class="card-caption">Find information on how to run your own workshop.</p>
+                        <a href="{{ site.baseurl }}/training/omero/" class="btn-blue button small">Workshop setup</a>
+                    </div>
+                </div>
+            </div>
+        </div>

--- a/training/index.html
+++ b/training/index.html
@@ -54,10 +54,10 @@ title: OMERO Training
             <div class="small-12 medium-3 columns">
                 <div class="card card-support">
                     <div class="card-section">
-                        <i class="border-blue icon-blue fa fa-file-alt fa-2x"></i>
+                        <i class="border-blue icon-blue fa fa-file fa-2x"></i>
                         <h4>Materials</h4>
                         <p class="card-caption">Browse training materials from recent workshops.</p>
-                        <a href="https://github.com/ome/training-repos/" target="_blank" class="btn-blue button small"></a>
+                        <a href="https://github.com/ome/training-repos/" target="_blank" class="btn-blue button small">Browse</a>
                     </div>
                 </div>
             </div>

--- a/training/index.html
+++ b/training/index.html
@@ -16,11 +16,6 @@ title: OMERO Training
         
 
         <hr class="whitespace">
-
-        <div class="row column text-center">
-            <h2>General</h2>
-        </div>
-        <hr>
         <div class="row column">
             <p>
                 The OME team is keen to provide outreach workshops in the community to

--- a/training/index.html
+++ b/training/index.html
@@ -9,7 +9,7 @@ title: OMERO Training
                 <h1>OME Training</h1>
                 <p>
                     To promote understanding of our products, regular practical workshops
-                    are organised in the community.
+                    are organized in the community.
                 </p>
             </div>
         </div>

--- a/training/omero/index.html
+++ b/training/omero/index.html
@@ -6,7 +6,7 @@ title: OMERO Training
         
         <div class="callout large primary" id="bg-image-omero">
             <div class="row column text-center">
-                <h1>OMERO Workhop Setup</h1>
+                <h1>OMERO Workshop Setup</h1>
                 <p>
                     All our training preparation materials are available to help you set up
                     and run your own OMERO workshop.
@@ -53,9 +53,7 @@ title: OMERO Training
                     </li>
                     <li>
                         <a href="https://github.com/openmicroscopy/prod-playbooks" target="_blank">
-                        Prod playbooks</a> for deployment of the OMERO training server at
-                        outreach.openmicroscopy.org.
-                    </li>
+                        Prod playbooks</a> for deployment of the OMERO training server.
                     <li>
                         <a href="https://github.com/ome/training-scripts" target="_blank">
                         Training scripts</a> provides maintenance scripts for managing user accounts and

--- a/training/omero/index.html
+++ b/training/omero/index.html
@@ -1,8 +1,7 @@
 ---
 layout: default
 title: OMERO Training
----     
-        {% include navbar-sub-omero.html %}
+---
         
         <div class="callout large primary" id="bg-image-omero">
             <div class="row column text-center">

--- a/training/omero/index.html
+++ b/training/omero/index.html
@@ -47,8 +47,9 @@ title: OMERO Training
                     <li>
                         <a href="https://github.com/ome/training-repos" target="_blank">Training
                         Repos</a> is the parent repository that links to the others below and
-                        is tagged for each workshop
-                        we run so that the precise version of all scripts and guides are known.
+                        is tagged for each workshop we run.
+                        This allows us to know the precise version of all scripts and guides
+                        used for each training session.
                     </li>
                     <li>
                         <a href="https://github.com/openmicroscopy/prod-playbooks" target="_blank">
@@ -64,7 +65,7 @@ title: OMERO Training
                     <li>
                         <a href="https://github.com/ome/training-notebooks" target="_blank">
                         Training notebooks</a> contains Jupyter notebooks used in the workshops and
-                        includes docker containers for deploying the Jupyter server.
+                        includes Docker containers for deploying the Jupyter server.
                     </li>
                 </ul>
             </p>

--- a/training/omero/index.html
+++ b/training/omero/index.html
@@ -18,7 +18,7 @@ title: OMERO Training
         <hr class="whitespace">
 
         <div class="row column text-center">
-            <h2>General</h2>
+            <h2>Workshop Preparation</h2>
         </div>
         <hr>
         <div class="row column">
@@ -26,24 +26,30 @@ title: OMERO Training
                 Preparation for an OMERO workshop includes server setup, configuration and import of
                 sample data. Guides are available to indicate where to download the data, what import steps to
                 perform and any scripts that are needed to prepare the data.
-                Some longer workflows also benefit from being parially completed
+                Some longer workflows also benefit from being partially completed
                 before the workshop.
             </p>
             <p>
                 If you are interested in running your own workshop, please contact us so we can
                 advise on what to include and how best to prepare for your attendees.
             </p>
+        </div>
 
+        <div class="row column text-center">
+            <h2>Training Repositories</h2>
+        </div>
+        <hr>
+        <div class="row column">
             <p>
-                The training resources are hosted on several github repositories, linked by a
-                central <a href="https://github.com/ome/training-repos" target="_blank">Training
-                Repos</a> repository. This allows us to tag that repository for each workshop
-                we run so that the precise version of all scripts and guides are known.
-            </p>
+                The training resources are hosted on several github repositories:
 
-            <p>
-                Training repositories are:
                 <ul>
+                    <li>
+                        <a href="https://github.com/ome/training-repos" target="_blank">Training
+                        Repos</a> is the parent repository that links to the others below and
+                        is tagged for each workshop
+                        we run so that the precise version of all scripts and guides are known.
+                    </li>
                     <li>
                         <a href="https://github.com/openmicroscopy/prod-playbooks" target="_blank">
                         Prod playbooks</a> for deployment of the OMERO training server at
@@ -61,4 +67,5 @@ title: OMERO Training
                         includes docker containers for deploying the Jupyter server.
                     </li>
                 </ul>
+            </p>
         </div>

--- a/training/omero/index.html
+++ b/training/omero/index.html
@@ -8,7 +8,7 @@ title: OMERO Training
             <div class="row column text-center">
                 <h1>OMERO Workhop Setup</h1>
                 <p>
-                    All our training preparation materials are available to help you setup
+                    All our training preparation materials are available to help you set up
                     and run your own OMERO workshop.
                 </p>
             </div>
@@ -41,7 +41,7 @@ title: OMERO Training
         <hr>
         <div class="row column">
             <p>
-                The training resources are hosted on several github repositories:
+                The training resources are hosted on several GitHub repositories:
 
                 <ul>
                     <li>
@@ -59,7 +59,7 @@ title: OMERO Training
                     <li>
                         <a href="https://github.com/ome/training-scripts" target="_blank">
                         Training scripts</a> provides maintenance scripts for managing user accounts and
-                        data on the training server as well as scripts for user's workflows in the
+                        data on the training server as well as scripts for users' workflows in the
                         workshop itself.
                     </li>
                     <li>

--- a/training/omero/index.html
+++ b/training/omero/index.html
@@ -1,0 +1,64 @@
+---
+layout: default
+title: OMERO Training
+---     
+        {% include navbar-sub-omero.html %}
+        
+        <div class="callout large primary" id="bg-image-omero">
+            <div class="row column text-center">
+                <h1>OMERO Workhop Setup</h1>
+                <p>
+                    All our training preparation materials are available to help you setup
+                    and run your own OMERO workshop.
+                </p>
+            </div>
+        </div>
+        
+
+        <hr class="whitespace">
+
+        <div class="row column text-center">
+            <h2>General</h2>
+        </div>
+        <hr>
+        <div class="row column">
+            <p>
+                Preparation for an OMERO workshop includes server setup, configuration and import of
+                sample data. Guides are available to indicate where to download the data, what import steps to
+                perform and any scripts that are needed to prepare the data.
+                Some longer workflows also benefit from being parially completed
+                before the workshop.
+            </p>
+            <p>
+                If you are interested in running your own workshop, please contact us so we can
+                advise on what to include and how best to prepare for your attendees.
+            </p>
+
+            <p>
+                The training resources are hosted on several github repositories, linked by a
+                central <a href="https://github.com/ome/training-repos" target="_blank">Training
+                Repos</a> repository. This allows us to tag that repository for each workshop
+                we run so that the precise version of all scripts and guides are known.
+            </p>
+
+            <p>
+                Training repositories are:
+                <ul>
+                    <li>
+                        <a href="https://github.com/openmicroscopy/prod-playbooks" target="_blank">
+                        Prod playbooks</a> for deployment of the OMERO training server at
+                        outreach.openmicroscopy.org.
+                    </li>
+                    <li>
+                        <a href="https://github.com/ome/training-scripts" target="_blank">
+                        Training scripts</a> provides maintenance scripts for managing user accounts and
+                        data on the training server as well as scripts for user's workflows in the
+                        workshop itself.
+                    </li>
+                    <li>
+                        <a href="https://github.com/ome/training-notebooks" target="_blank">
+                        Training notebooks</a> contains Jupyter notebooks used in the workshops and
+                        includes docker containers for deploying the Jupyter server.
+                    </li>
+                </ul>
+        </div>

--- a/training/omero/index.html
+++ b/training/omero/index.html
@@ -48,8 +48,8 @@ title: OMERO Training
                         <a href="https://github.com/ome/training-repos" target="_blank">Training
                         Repos</a> is the parent repository that links to the others below and
                         is tagged for each workshop we run.
-                        This allows us to know the precise version of all scripts and guides
-                        used for each training session.
+                        This allows us to know the precise version of all software, scripts
+                        and guides used for each training session.
                     </li>
                     <li>
                         <a href="https://github.com/openmicroscopy/prod-playbooks" target="_blank">


### PR DESCRIPTION
See https://trello.com/c/2VSqMQmj/18-website-training-page-update

Ready for first look at these pages.
Added link to training page from "About Us" menu and support page.

Will be staged at https://snoopycrimecop.github.io/www.openmicroscopy.org/training/
once build is run.

cc @jburel @pwalczysko 