### PR TITLE
minor adjustments to Bio-Formats 5.9.1 release notes

### DIFF
--- a/_posts/2018-08-14-bio-formats-5-9-1.md
+++ b/_posts/2018-08-14-bio-formats-5-9-1.md
@@ -9,20 +9,20 @@ Today we are releasing Bio-Formats 5.9.1 which includes the following changes:
 File format fixes and improvements:
 
 * Olympus OIR
-    * fixed a bug to prevent the incorrect file from being read when multiple datasets are in the same location
+    * fixed a bug to prevent incorrect files from being read when multiple datasets are in the same location
 * LEO
-    * updated parsing of metadata values for image pixel size, working distance, filament, EHT and date(thanks to David Mankus)
-* Deltavision
+    * updated parsing of metadata values for image pixel size, working distance, filament, EHT and date (thanks to David Mankus)
+* DeltaVision
     * reader can now detect up to 12 channels
 * Micro-Manager
-    * added a warning to the logging when an image is acquired with an unsupported version
+    * now logs a warning when an image is acquired with an unsupported version
 
 Documentation improvements:
 
 * added QuPath to the list of visualization and analysis applications
 * updated the link to the i3dcore library
 * updated the link to Slidebook
-* improved MATLAB documentation with information on java heap memory preferences (thanks to Kouichi C. Nakamura)
+* improved MATLAB documentation with information on Java heap memory preferences (thanks to Kouichi C. Nakamura)
 * corrected a number of permanently redirected URLs in the component and format pages
 
 Full details can be found at [Bio-Formats version history](https://docs.openmicroscopy.org/bio-formats/5.9.1/about/whats-new.html).


### PR DESCRIPTION
Minor stylistic adjustments to the text of the Bio-Formats 5.9.1 release notes, mirroring https://github.com/ome/bio-formats-documentation/pull/47.