### PR TITLE
No top links

### DIFF
--- a/_includes/navbar-main.html
+++ b/_includes/navbar-main.html
@@ -12,6 +12,7 @@
                     <li class="show-for-small-only"><a href="{{ site.baseurl }}/index.html"><img src="{{ site.baseurl }}/img/logos/ome-logomark.svg" alt="OME logo" style="height:32px; width:32px;"/></a></li>
                     <li class="has-submenu"><a href="{{ site.baseurl }}/about/">About Us</a>
                         <ul class="submenu menu vertical" data-submenu>
+                            <li><a href="{{ site.baseurl }}/about/">Overview</a></li>
                             <li><a href="{{ site.baseurl }}/teams/">OME Teams</a></li>
                             <li><a href="{{ site.baseurl }}/contributors/">Contributors</a></li>
                             <li><a href="{{ site.baseurl }}/commercial-partners/">Commercial Partners</a></li>
@@ -23,6 +24,7 @@
                     </li>
                     <li class="has-submenu"><a href="{{ site.baseurl }}/news/">News</a>
                         <ul class="submenu menu vertical" data-submenu>
+                            <li><a href="{{ site.baseurl }}/news/">Overview</a></li>
                             <li><a href="{{ site.baseurl }}/announcements/">Announcements</a></li>
                             <li><a href="{{ site.baseurl }}/events/">Events</a></li>
                             <li><a href="{{ site.baseurl }}/security/">Security</a></li>
@@ -36,6 +38,7 @@
                 <ul class="vertical medium-horizontal dropdown menu" data-responsive-menu="accordion medium-dropdown">
                     <li class="has-submenu"><a href="{{ site.baseurl }}/products/">Products</a>
                         <ul class="submenu menu vertical" data-submenu>
+                            <li><a href="{{ site.baseurl }}/products/">Overview</a></li>
                             <li><a href="{{ site.baseurl }}/omero/">OMERO</a></li>
                             <li><a href="{{ site.baseurl }}/bio-formats/">Bio-Formats</a></li>
                             <li><a href="{{ site.baseurl }}/ome-files/">OME Files</a></li>
@@ -43,6 +46,7 @@
                     </li>
                     <li class="has-submenu"><a href="{{ site.baseurl }}/support/">Support</a>
                         <ul class="submenu menu vertical" data-submenu>
+                            <li><a href="{{ site.baseurl }}/support/">Overview</a></li>
                             <li><a href="{{ site.baseurl }}/training/">Training</a></li>
                         </ul>
                     </li>

--- a/css/openmicroscopy.css
+++ b/css/openmicroscopy.css
@@ -190,6 +190,12 @@ h3.subdivider {
     color: #03a9f4;
 }
 
+/* These top menu links only expand submenu - we don't want them to look like links */
+#main-menu .has-submenu>a:hover {
+    color: #37474f;
+    cursor: default;
+}
+
 #main-menu .dropdown.menu > li.is-dropdown-submenu-parent > a::after { border-color: #37474f transparent transparent; }
 
 .header-subnav {

--- a/js/app.js
+++ b/js/app.js
@@ -1,1 +1,8 @@
 $(document).foundation()
+
+$(function(){
+	// We don't want main menu top links to be 'active' as links
+	// We can't replace the <a> because foundation uses them for collapsible menu on mobile
+	// and we can't set href="#" since the travis build fails.
+	$("#main-menu .has-submenu>a").click(event => event.preventDefault());
+});


### PR DESCRIPTION
This is an attempt to fix the issue of the top menu items being links (as well as toggling submenus) as discussed in #245.
It means that the pages linked to by the top links can be missed. Also, they are not reachable on mobile-sized screen, since they *only* toggle the submenu when on a small screen and don't behave as links.

With this PR, the main landing pages are linked to with an "Overview" link that is the first link in each sub-menu.
It hasn't been possible to remove the ```<a>``` links since they are used by foundation.js to toggle the mobile links menu, but we can disable their default link behaviour with ```preventDefault()```.

To test, try clicking top-links and their submenu items with large screen and small screen (can just resize your browser to phone-size).